### PR TITLE
[BE] 카카오 장소 정보 -> DB 연동 기능 구현

### DIFF
--- a/src/main/java/com/dateplanner/api/dto/DocumentDto.java
+++ b/src/main/java/com/dateplanner/api/dto/DocumentDto.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
+
 @Slf4j(topic = "DTO")
 @Getter
 @AllArgsConstructor
@@ -29,17 +31,6 @@ public class DocumentDto {
     @JsonProperty("address_name")
     private String addressName;
 
-    /*
-    @JsonProperty("region_1depth_name")
-    private String region1DepthName;
-
-    @JsonProperty("region_2depth_name")
-    private String region2DepthName;
-
-    @JsonProperty("region_3depth_name")
-    private String region3DepthName;
-     */
-
     @JsonProperty("x")
     private String longitude;
 
@@ -48,5 +39,18 @@ public class DocumentDto {
 
     @JsonProperty("distance")
     private String distance;
+    
+    private String region1DepthName;
+
+    private String region2DepthName;
+
+    private String region3DepthName;
+
+    public void splitAddress(String addressName) {
+        String[] arr = addressName.split(" ", 3);
+        this.region1DepthName = arr[0];
+        this.region2DepthName = arr[1];
+        this.region3DepthName = arr[2];
+    }
 
 }

--- a/src/main/java/com/dateplanner/api/service/KakaoAddressSearchService.java
+++ b/src/main/java/com/dateplanner/api/service/KakaoAddressSearchService.java
@@ -48,7 +48,7 @@ public class KakaoAddressSearchService {
 
         // URI 호출
         URI uri = kakaoUriBuilderService.buildUriForAddressSearch(address);
-        log.info("[KakaoAddressSearchService requestAddressSearch] URI converting complete", uri);
+        log.info("[KakaoAddressSearchService requestAddressSearch] URI converting complete, {}", uri);
 
         // 요청 헤더 세팅
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/dateplanner/api/service/KakaoCategorySearchService.java
+++ b/src/main/java/com/dateplanner/api/service/KakaoCategorySearchService.java
@@ -42,7 +42,7 @@ public class KakaoCategorySearchService {
 
         // URI 호출
         URI uri = kakaoUriBuilderService.buildUriForCategorySearch(latitude, longitude, radius, category);
-        log.info("[KakaoCategorySearchService requestCategorySearch] URI converting complete", uri);
+        log.info("[KakaoCategorySearchService requestCategorySearch] URI converting complete, {}", uri);
 
         // 요청 헤더 세팅
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/dateplanner/place/controller/PlaceApiController.java
+++ b/src/main/java/com/dateplanner/place/controller/PlaceApiController.java
@@ -1,9 +1,6 @@
 package com.dateplanner.place.controller;
 
 import com.dateplanner.api.dto.DocumentDto;
-import com.dateplanner.api.dto.KakaoApiResponseDto;
-import com.dateplanner.api.service.KakaoAddressSearchService;
-import com.dateplanner.api.service.KakaoCategorySearchService;
 import com.dateplanner.place.dto.PlaceDto;
 import com.dateplanner.place.service.PlaceApiService;
 import com.dateplanner.place.service.PlaceService;
@@ -12,13 +9,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.util.ObjectUtils;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 
 @Slf4j(topic = "CONTROLLER")
 @Tag(name = "PlaceApiController")
@@ -26,39 +24,32 @@ import java.util.Objects;
 @RestController
 public class PlaceApiController {
 
-    private final KakaoAddressSearchService kakaoAddressSearchService;
-    private final KakaoCategorySearchService kakaoCategorySearchService;
+    /**
+     * PlaceService : KAKAO API를 통한 API 호출 및 장소 정보 DB 저장 등 핵심 비즈니스 로직 담당
+     * PlaceApiService : 화면 처리를 위한 전용 서비스
+     */
+
     private final PlaceApiService placeApiService;
     private final PlaceService placeService;
 
-    private static final int MAX_LADIUS = 5;
-
+    /**
+     * 초기 버전은 KAKAO 카테고리 검색 결과를 받아 페이징 / 정렬 처리를 하고 화면 처리를 하지만
+     * 추후 추가 기능이 붙어야 한다면 고도화가 필요할 것으로 보인다. (DB에 저장된 장소들 / 카카오 API에서 가져온 정보들 분리해서 출력)
+     */
     @Operation(summary = "Place List", description = "[GET] 주소, 카테고리로 장소 리스트 출력")
     @GetMapping("/api/v1/places")
-    public List<DocumentDto> placesV1(String address, String category) {
+    public Page<DocumentDto> placesV1(String address, String category, @PageableDefault(size = 10, sort = "reviewScore") Pageable pageable) {
 
-        // TODO 1 : List<DocumentDto> -> Page<PlaceDto> 로 변경 필요
-        // TODO 2 : 임시 테스트로 여기에서 API 서비스를 바로 호출하지만 SearchService 구축 후에는 SearchService에서 API 서비스 호출
+        List<DocumentDto> dtos =  placeService.placeSearch(address, category);
+        placeService.placePersist(dtos);
+        return placeApiService.places(dtos, pageable);
+    }
 
-        List<DocumentDto> addressResults = kakaoAddressSearchService.requestAddressSearch(address).getDocumentList();
+    @Operation(summary = "Place", description = "[GET] 장소 ID로 단일 장소 정보 조회")
+    @GetMapping("/api/v1/places/{place_id}")
+    public PlaceDto getPlaceV1(@PathVariable("place_id")String placeId) {
 
-        if (Objects.isNull(addressResults) || addressResults.isEmpty()) {
-            log.error("[PlaceApiController placesV1] result is null");
-            return Collections.emptyList();
-        }
-
-        DocumentDto addressDto = addressResults.get(0);
-
-        List<DocumentDto> result = kakaoCategorySearchService.requestCategorySearch(
-                Double.valueOf(addressDto.getLatitude()), Double.valueOf(addressDto.getLongitude()), MAX_LADIUS, category
-        ).getDocumentList();
-
-        if (Objects.isNull(result) || result.isEmpty()) {
-            log.error("[PlaceApiController placesV1] result is null");
-            return Collections.emptyList();
-        }
-
-        return result;
+        return placeApiService.getPlace(placeId);
     }
 
 }

--- a/src/main/java/com/dateplanner/place/dto/PlaceDto.java
+++ b/src/main/java/com/dateplanner/place/dto/PlaceDto.java
@@ -1,5 +1,6 @@
 package com.dateplanner.place.dto;
 
+import com.dateplanner.place.entity.Place;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -45,5 +46,19 @@ public class PlaceDto {
 
     private Long reviewScore;
     private Long reviewCount;
+
+    public static PlaceDto from(Place entity) {
+        return PlaceDto.builder()
+                .placeName(entity.getPlaceName())
+                .placeId(entity.getPlaceId())
+                .placeUrl(entity.getPlaceUrl())
+                .addressName(entity.getAddressName())
+                .region1DepthName(entity.getRegion1DepthName())
+                .region2DepthName(entity.getRegion2DepthName())
+                .region3DepthName(entity.getRegion3DepthName())
+                .reviewScore(entity.getReviewScore())
+                .reviewCount(entity.getReviewCount())
+                .build();
+    }
 
 }

--- a/src/main/java/com/dateplanner/place/entity/Category.java
+++ b/src/main/java/com/dateplanner/place/entity/Category.java
@@ -5,19 +5,41 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.domain.Persistable;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
 @Entity
-@Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Category extends BaseEntity {
+public class Category extends BaseEntity implements Persistable<String> {
 
     @Id
+    @Column(name = "category_id")
     private String id;
 
     private String categoryName;
+
+    private Category(String id) {
+        this.id = id;
+    }
+
+    public static Category of(String id) {
+        return new Category(id);
+    }
+
+    // persistable 재정의
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isNew() {
+        return getCreatedAt() == null;
+    }
 
 }

--- a/src/main/java/com/dateplanner/place/repository/PlaceRepository.java
+++ b/src/main/java/com/dateplanner/place/repository/PlaceRepository.java
@@ -3,5 +3,11 @@ package com.dateplanner.place.repository;
 import com.dateplanner.place.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+    boolean existsByPlaceId(String placeId);
+
+    Optional<Place> findByPlaceId(String placeId);
 }

--- a/src/main/java/com/dateplanner/place/service/PlaceApiService.java
+++ b/src/main/java/com/dateplanner/place/service/PlaceApiService.java
@@ -1,11 +1,40 @@
 package com.dateplanner.place.service;
 
+import com.dateplanner.api.dto.DocumentDto;
+import com.dateplanner.place.dto.PlaceDto;
+import com.dateplanner.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
 
 @Slf4j(topic = "SERVICE")
 @RequiredArgsConstructor
 @Service
 public class PlaceApiService {
+
+    private final PlaceRepository placeRepository;
+
+    /**
+     * 초기 버전은 KAKAO 카테고리 검색 결과를 받아 페이징 / 정렬 처리를 하고 화면 처리를 하지만
+     * 추후 추가 기능이 붙어야 한다면 고도화가 필요할 것으로 보인다.
+     */
+    public Page<DocumentDto> places(List<DocumentDto> dtos, Pageable pageable) {
+        final int start = (int) pageable.getOffset();
+        final int end = Math.min((start + pageable.getPageSize()), dtos.size());
+        return new PageImpl<>(dtos.subList(start, end), pageable, dtos.size());
+    }
+
+    /**
+     * KAKAO API 상의 place_id를 DB에서 조회하여 정보를 가져온다 (상세 정보, 리뷰 유무, 평점, 리뷰 수 등)
+     */
+    public PlaceDto getPlace(String placeId) {
+        return placeRepository.findByPlaceId(placeId).map(PlaceDto::from).orElseThrow(EntityNotFoundException::new);
+    }
+
 }

--- a/src/main/java/com/dateplanner/place/service/PlaceService.java
+++ b/src/main/java/com/dateplanner/place/service/PlaceService.java
@@ -1,11 +1,108 @@
 package com.dateplanner.place.service;
 
+import com.dateplanner.api.dto.DocumentDto;
+import com.dateplanner.api.service.KakaoAddressSearchService;
+import com.dateplanner.api.service.KakaoCategorySearchService;
+import com.dateplanner.place.entity.Category;
+import com.dateplanner.place.entity.Place;
+import com.dateplanner.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.*;
 
 @Slf4j(topic = "SERVICE")
 @RequiredArgsConstructor
 @Service
 public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+    private final KakaoAddressSearchService kakaoAddressSearchService;
+    private final KakaoCategorySearchService kakaoCategorySearchService;
+    private final PlaceApiService placeApiService;
+    private static final int MAX_LADIUS = 5;
+
+    public List<DocumentDto> placeSearch(String address, String category) {
+
+        /**
+         * KAKAO 주소 검색하기 API 호출하여 주소 변환
+         */
+
+        List<DocumentDto> addressResults = kakaoAddressSearchService.requestAddressSearch(address).getDocumentList();
+
+        if (Objects.isNull(addressResults) || addressResults.isEmpty()) {
+            log.error("[PlaceService placeSearch] address search result is null");
+            return Collections.emptyList();
+        }
+
+        /**
+         * 변환된 주소 + 카테고리 + 설정 범위로 KAKAO 카테고리로 장소 검색하기 API 호출하여 장소 리스트 전달 받기
+         */
+
+        DocumentDto addressDto = addressResults.get(0);
+
+        List<DocumentDto> results = kakaoCategorySearchService.requestCategorySearch(
+                Double.valueOf(addressDto.getLatitude()), Double.valueOf(addressDto.getLongitude()), MAX_LADIUS, category
+        ).getDocumentList();
+
+        if (Objects.isNull(results) || results.isEmpty()) {
+            log.error("[PlaceService placeSearch] category search result is null");
+            return Collections.emptyList();
+        }
+
+        return results;
+    }
+
+    public Map<String, Long> placePersist(List<DocumentDto> results) {
+
+        // 결과 HashMap
+        Map<String, Long> resultMap = new HashMap<>();
+
+        if (Objects.isNull(results) || results.isEmpty()) {
+            log.error("[PlaceService placePersist] category search result is null");
+            resultMap.put("number of saved places : ", null);
+            return resultMap;
+        }
+
+        /**
+         * 전달 받은 장소 리스트 DB 내 중복 여부 체크 후 DB에 저장
+         */
+
+        log.info("[PlaceService placeSearchAndSave] DocumentDto -> Repository save start");
+        int convertResultCount = 0;
+        int nestedResultCount = 0;
+
+        for (DocumentDto result : results) {
+
+            result.splitAddress(result.getAddressName());
+            if (placeRepository.existsByPlaceId(result.getPlaceId())) {
+                nestedResultCount += 1;
+            }
+
+            if (!placeRepository.existsByPlaceId(result.getPlaceId())) {
+                placeRepository.save(Place.of(
+                        Category.of(result.getCategoryGroupId()),
+                        result.getPlaceName(),
+                        result.getPlaceId(),
+                        result.getPlaceUrl(),
+                        result.getAddressName(),
+                        result.getRegion1DepthName(),
+                        result.getRegion2DepthName(),
+                        result.getRegion3DepthName(),
+                        result.getLongitude(),
+                        result.getLatitude(),
+                        0L,
+                        0L));
+                convertResultCount += 1;
+            }
+        }
+
+        resultMap.put("number of saved places : ", Long.valueOf(convertResultCount));
+        resultMap.put("number of nested places : ", Long.valueOf(nestedResultCount));
+        resultMap.put("total number of searched places : ", Long.valueOf(results.size()));
+        log.info("persist complete, {}", resultMap);
+        return resultMap;
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,11 @@
+INSERT INTO category (category_id, created_at, modified_at, category_name) values
+('MT1', now(), now(), '대형 마트'),
+('CS2', now(), now(), '편의점'),
+('PK6', now(), now(), '주차장'),
+('OL7', now(), now(), '주유소, 충전소'),
+('SW8', now(), now(), '지하철역'),
+('CT1', now(), now(), '문화시설'),
+('AT4', now(), now(), '관광명소'),
+('AD5', now(), now(), '숙박'),
+('FD6', now(), now(), '음식점'),
+('CE7', now(), now(), '카페');


### PR DESCRIPTION
카카오 API를 통해 가져온 장소 정보를 DB에 연동하고 이를 토대로 사용자에게 정보를 제공할 수 있도록 한다

* [x] 카카오 API 장소 정보 -> DB 저장
* [x] 장소 정보 조회 (전체, 단건)
* [x] 페이징 기능 (페이지 혹은 슬라이스)
* [x] 테스트
  * [x] 테스트 케이스 작성
  * [x] 카카오 API 장소 정보 -> DB 저장 (DB에 없는 경우 / DB에 있는 경우)
  * [x] 장소 정보 조회 (전체 / 단건)
  * [x] 페이징 기능

This closes #13 