### PR TITLE
[BE] CORS 처리 관련 수정

### DIFF
--- a/src/main/java/com/dateplanner/config/SecurityConfig.java
+++ b/src/main/java/com/dateplanner/config/SecurityConfig.java
@@ -20,6 +20,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 @Slf4j(topic = "SECURITY")
 @Configuration
@@ -33,7 +38,6 @@ public class SecurityConfig {
 
     private final JwtProvider jwtProvider;
 
-    // TODO: 인증 기능 추후 구현
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
@@ -61,6 +65,11 @@ public class SecurityConfig {
 
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
+        // CORS
+        http.cors(httpSecurityCorsConfigurer -> {
+            httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource());
+        });
+
         return http
                 // 어노테이션 형식으로 변경하였음
 //                .authorizeHttpRequests(auth -> auth
@@ -85,6 +94,20 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    // CORS 관련 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(Arrays.asList("*"));
+        configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE")); // 허용할 메서드
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type")); // 허용할 Http 헤더
+        configuration.setAllowCredentials(true);
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
 }


### PR DESCRIPTION
REST API를 활용할 시 Ajax의 동일 출처 정책 (same-origin policy)으로 인한 CORS 문제가 반드시 발생할 수 밖에 없다.
또한 GET 방식이 아닌 POST 방식을 이용할 때 발생하는 Preflight 문제도 있다.
따라서 SecurityConfig를 수정하여 처리를 해야 한다. 또한 추가로 처리해야 할 것이 무엇인지 확인해보고 조치해본다

* [x] CORS 처리 (SecurityConfig)
* [x] 그 외 레퍼런스 탐색

서버 단에서 CORS 처리를 하는 방법은 3가지가 있는 것으로 확인
- Spring Security 설정 Configuration에서 `CorsConfigurationSource()` 설정을 통해 처리 (Filter 단위에서 처리)
- 컨트롤러의 클래스명이나 메서드에 `@CrossOrigin` 어노테이션을 부착하여 처리
- WebMvcConfigure 에서 `addCorsMappings()`를 재정의

해당 프로젝트에서는 `CorsConfigurationSource()` 설정을 통해 처리하도록 한다

This closes #23 