### PR TITLE
[BE] 백엔드 API 서버 DB 컨테이너 관련 버그 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM openjdk:11
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} ./app.jar
 ENV TZ=Asia/Seoul
-ENV SPRING_PROFILE = "dev"
+ENV SPRING_PROFILE="dev"
 ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILE}", "-jar", "./app.jar"]
 EXPOSE 8084

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,3 +1,4 @@
-FROM mariadb:10
+FROM mariadb:10.2
+#latest 버전으로 가져왔을 때 can't initialize 오류가 발생, 강제로 10.2 버전 (현재 홈 리눅스 버전이 16.04버전이므로)
 
 ENV TZ=Asia/Seoul

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "2" # 원래 3.8이었으나 리눅스 환경에서 build 하기 위해 2.0으로 변경
 services:
   backend-database:
     container_name: backend-database
@@ -11,7 +11,7 @@ services:
       - MARIADB_ROOT_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
     volumes:
       - ./database/config:/etc/mysql/conf.d
-      #- ./database/init:/docker-entrypoint-initdb.d
+      - ./database/init:/docker-entrypoint-initdb.d
     env_file:
       - .env
     ports:
@@ -28,5 +28,8 @@ services:
       - KAKAO_REST_API_KEY=${KAKAO_REST_API_KEY}
     ports:
       - "81:8084" # 기본 포트
+    volumes:
+      - /home/mrcocoball/date_planner/image:/home/mrcocoball/date_planner/image
+      # 호스트 경로 : 컨테이너 내부 경로 mount(연결) (해당 내용 지정 안할 경우 컨테이너 내부의 경로에만 저장이 됨)
     restart: always # depends on은 실행 순서만 컨트롤, 컨테이너 안의 서비스가 실행 가능한 상태인지는 확인하지 않으므로
-                    # DB가 실행 가능한 상태가 아니여서 실패할 경우 재시작하도록 설정
+    # DB가 실행 가능한 상태가 아니여서 실패할 경우 재시작하도록 설정

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,8 @@ spring:
   config:
     activate:
       on-profile: common
+  jpa:
+    open-in-view: false
 
 kakao:
   rest:
@@ -56,6 +58,17 @@ spring:
   sql:
     init:
       mode: always
+  servlet:
+    multipart:
+      enabled: true
+      location: D:\\upload
+      max-request-size: 5MB
+      max-file-size: 4MB
+
+com:
+  dateplanner:
+    upload:
+      path: D:\\upload
 
 ---
 spring:
@@ -64,7 +77,6 @@ spring:
       on-profile: dev
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-#    url: jdbc:mariadb://localhost:4000/date_planner
     url: jdbc:mariadb://backend-database:3306/backend-database
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
@@ -83,4 +95,16 @@ spring:
   sql:
     init:
       mode: always
+  servlet:
+    multipart:
+      enabled: true
+      location: /home/mrcocoball/date_planner/image
+      max-request-size: 5MB
+      max-file-size: 4MB
+
+com:
+  dateplanner:
+    upload:
+      path: /home/mrcocoball/date_planner/image
+
 ---


### PR DESCRIPTION
* 현재 DB 컨테이너가 build 도중 죽어버려서 연결이 되지 않는 버그가 있음
![Image](https://user-images.githubusercontent.com/109284797/216357196-00e21d40-256f-4a2f-a784-fd24c00089ea.png)

* 확인을 해보니 mariaDB 버전 관련 이슈가 있어서 10.2 버전으로 강제 다운그레이드하여 build하니 해결되었음
```yml
FROM mariadb:10.2
#latest 버전으로 가져왔을 때 can't initialize 오류가 발생, 강제로 10.2 버전 (현재 홈 리눅스 버전이 16.04버전이므로)

ENV TZ=Asia/Seoul
```

* 추가로, docker-compose 상에서 호스트와 컨테이너 바인드 마운트를 하지 않아 이미지가 호스트 내 폴더에 저장되지 않던 이슈가 있어서 수정하였음
```yml
  backend-app:
    container_name: backend-app
    depends_on: # DB 컨테이너 실행 후 WEB을 실행시킴
      - backend-database
    image: mrcocoball/dateplanner_backend:dev
    environment: # .env 파일에 저장했던 환경 변수
      - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
      - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
      - KAKAO_REST_API_KEY=${KAKAO_REST_API_KEY}
    ports:
      - "81:8084" # 기본 포트
    volumes:
      - /home/mrcocoball/date_planner/image:/home/mrcocoball/date_planner/image
      # 호스트 경로 : 컨테이너 내부 경로 mount(연결) (해당 내용 지정 안할 경우 컨테이너 내부의 경로에만 저장이 됨)
```

This closes #35 