### PR TITLE
[BE] 인덱스 적용 대상 테이블 정리

### DIFF
--- a/src/main/java/com/dateplanner/InitCategory.java
+++ b/src/main/java/com/dateplanner/InitCategory.java
@@ -1,6 +1,9 @@
 package com.dateplanner;
 
 import com.dateplanner.place.entity.Category;
+import com.dateplanner.place.entity.Place;
+import com.dateplanner.review.entity.Review;
+import com.dateplanner.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +30,14 @@ public class InitCategory {
 
         @Transactional
         public void init() {
+
+            /*
+            // Mock User 생성
+            User user = User.of("test", "tset", "test", "test", false, false);
+            em.persist(user);
+             */
+
+
             Category CE7 = Category.of("CE7", "카페");
             Category MT1 = Category.of("MT1", "대형 마트");
             Category CS2 = Category.of("CS2", "편의점");
@@ -48,6 +59,25 @@ public class InitCategory {
             em.persist(AT4);
             em.persist(AD5);
             em.persist(FD6);
+
+            /*
+            // 장소
+            for (int i = 0; i < 1000; i++) {
+                Long number = Long.valueOf(i);
+                Place place = Place.of(CE7, "장소" + i, Long.toString(number),
+                        "url", "서울시 관악구 청룡동", "add0", "add1", "add2", "add3", 10, 10, 1L,5L);
+                em.persist(place);
+            }
+
+            // 리뷰
+            for (int i = 0; i < 1000; i++) {
+                Place place = Place.of(CE7, "장소", "1001", "url", "서울시 관악구 청룡동", "add0", "add1", "add2", "add3", 10, 10, 1L, 5L);
+                em.persist(place);
+                Review review = Review.of(user, place, "1001", "title", "description", 5L);
+                em.persist(review);
+            }
+             */
+
         }
     }
 }

--- a/src/main/java/com/dateplanner/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/dateplanner/bookmark/entity/Bookmark.java
@@ -10,6 +10,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.*;
 
 @Slf4j(topic = "ENTITY")
+@Table(indexes = {
+        @Index(columnList = "kpid"),
+        @Index(columnList = "createdAt")
+})
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dateplanner/bookmark/service/BookmarkApiService.java
+++ b/src/main/java/com/dateplanner/bookmark/service/BookmarkApiService.java
@@ -24,9 +24,16 @@ public class BookmarkApiService {
 
     public Page<BookmarkDto> getBookmarkList(String uid, Pageable pageable) {
 
+        // 인덱스 계산용 시간 측정
+        long beforeTime = System.currentTimeMillis();
+
         log.info("[BookmarkApiService getBookmarkList] get bookmark list start...");
         List<BookmarkDto> dtos = bookmarkRepository.findByUser_Uid(uid).stream().map(BookmarkDto::from).collect(Collectors.toList());
         log.info("[BookmarkApiService getBookmarkList] get bookmark list complete, size : {}", dtos.size());
+
+        // 인덱스 계산용 시간 측정
+        long afterTime = System.currentTimeMillis();
+        log.info("elapsed time : " + (afterTime-beforeTime));
 
         return paginationService.listToPage(dtos, pageable);
     }

--- a/src/main/java/com/dateplanner/place/entity/Place.java
+++ b/src/main/java/com/dateplanner/place/entity/Place.java
@@ -9,6 +9,10 @@ import lombok.extern.slf4j.Slf4j;
 import javax.persistence.*;
 
 @Slf4j(topic = "ENTITY")
+@Table(indexes = {
+        @Index(columnList = "placeId"),
+        @Index(columnList = "createdAt")
+})
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dateplanner/place/service/PlaceApiService.java
+++ b/src/main/java/com/dateplanner/place/service/PlaceApiService.java
@@ -55,6 +55,9 @@ public class PlaceApiService {
 
         log.info("[PlaceApiService getPlacesByKeyword] target address : {}", searchAddress);
 
+        // 인덱스 계산용 시간 측정
+        long beforeTime = System.currentTimeMillis();
+
         // 1depth_name, 2depth_name 기준으로 장소 Dto 가져오기
         List<PlaceDto> placeDtos = placeRepository.findByAddressNameStartingWithAndCategory_Id(searchAddress, category)
                 .stream()
@@ -62,6 +65,10 @@ public class PlaceApiService {
                 .collect(Collectors.toList());
 
         log.info("[PlaceApiService getPlacesByKeyword] places {} found", placeDtos.size());
+
+        // 인덱스 계산용 시간 측정
+        long afterTime = System.currentTimeMillis();
+        log.info("elapsed time : " + (afterTime-beforeTime));
 
         // 장소 Dto 와 기준점과의 거리 계산하여 필터링 후 최종 리스트에 저장
         double latitude = addressDto.getLatitude();

--- a/src/main/java/com/dateplanner/review/entity/Review.java
+++ b/src/main/java/com/dateplanner/review/entity/Review.java
@@ -13,6 +13,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Slf4j(topic = "ENTITY")
+@Table(indexes = {
+        @Index(columnList = "kpid"),
+        @Index(columnList = "createdAt")
+})
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dateplanner/review/service/ReviewApiService.java
+++ b/src/main/java/com/dateplanner/review/service/ReviewApiService.java
@@ -26,9 +26,16 @@ public class ReviewApiService {
 
     public Page<ReviewDto> getReviewListByPlaceId(String placeId, Pageable pageable) {
 
+        // 인덱스 계산용 시간 측정
+        long beforeTime = System.currentTimeMillis();
+
         log.info("[ReviewApiService getReviewList] get review list start...");
         List<ReviewDto> dtos = reviewRepository.findByKpid(placeId).stream().map(ReviewDto::from).collect(Collectors.toList());
         log.info("[ReviewApiService getReviewList] get review list complete, size : {}", dtos.size());
+
+        // 인덱스 계산용 시간 측정
+        long afterTime = System.currentTimeMillis();
+        log.info("elapsed time : " + (afterTime-beforeTime));
 
         return paginationService.listToPage(dtos, pageable);
     }


### PR DESCRIPTION
검색 성능 최적화를 위해 각 테이블에 인덱스를 적용할 수 있는지 확인 후 인덱스를 적용한다

* [x] 인덱스 적용 대상 확인
* [x] 인덱스 적용, 테스트
* 인덱스 적용 테이블과 칼럼은 다음과 같다
  * 장소 : placeId(PK 아님, 카카오 API에서 가져오는 장소별 ID), 생성일시
  * 리뷰 : kpid(=장소의 placeId), 생성일시
  * 북마크 : kpid(=장소의 placeId), 생성일시
* 장소, 리뷰 Mock Data 2000건 삽입 후 인덱스 미적용 / 적용 테스트를 해본 결과 미미하지만 조회 성능이 증가하였음
  * 좌 : 미적용 / 우 : 적용
  * 1회차 : 123 / 110 (ms)
  * 2회차 : 76 / 49 (ms)

This closes #37 