### PR TITLE
[BE] 지역별 명소 추천 기능 추가

### DIFF
--- a/src/main/java/com/dateplanner/config/QueryDslConfig.java
+++ b/src/main/java/com/dateplanner/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.dateplanner.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}
+

--- a/src/main/java/com/dateplanner/place/controller/PlaceRecommendationApiController.java
+++ b/src/main/java/com/dateplanner/place/controller/PlaceRecommendationApiController.java
@@ -1,0 +1,41 @@
+package com.dateplanner.place.controller;
+
+import com.dateplanner.api.model.PageResult;
+import com.dateplanner.api.service.ResponseService;
+import com.dateplanner.place.dto.PlaceRecommendationDto;
+import com.dateplanner.place.service.PlaceRecommendationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "CONTROLLER")
+@Tag(name = "PlaceRecommendationApiController - 장소 추천 API")
+@RequiredArgsConstructor
+@RestController
+public class PlaceRecommendationApiController {
+
+    private final PlaceRecommendationService placeRecommendationService;
+    private final ResponseService responseService;
+
+
+    // TODO : 현재는 카테고리 무관하게 평점 순 상위 50개 장소를 추천해주고 있으나, 카테고리 별로 가져와야 할 경우 10개씩 5번 쿼리를 날려야 할 것으로 보임
+    //  아니면 넉넉하게 한 번에 카테고리 무관하게 100개 정도 가져오고 애플리케이션 내에서 카테고리별로 모아서 뿌리는 방법도 있으나 카테고리 별로 10개가 무조건 나온다는 보장은 없어 고민이 필요
+
+    @Operation(summary = "장소 추천", description = "[GET] 선택된 주소 정보 (시/도, 군/구, 동/읍/면) 기반 카테고리 무관 평점 순 상위 50개 장소 추천")
+    @GetMapping("/api/v1/recommendation")
+    public PageResult<PlaceRecommendationDto> getRecommendationV1(@Parameter(description = "시/도") @RequestParam(required = false) String region1,
+                                                                  @Parameter(description = "군/구") @RequestParam(required = false) String region2,
+                                                                  @Parameter(description = "동/읍/면") @RequestParam(required = false) String region3,
+                                                                  @PageableDefault(size = 10, sort = "avgReviewScore") Pageable pageable) {
+
+        return responseService.getPageResult(placeRecommendationService.getPlaceRecommendation(region1, region2, region3, pageable));
+    }
+
+}

--- a/src/main/java/com/dateplanner/place/dto/PlaceRecommendationDto.java
+++ b/src/main/java/com/dateplanner/place/dto/PlaceRecommendationDto.java
@@ -1,0 +1,64 @@
+package com.dateplanner.place.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "DTO")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlaceRecommendationDto {
+
+    private Long id;
+
+    @JsonProperty("category_group_id")
+    private String categoryGroupId;
+
+    @JsonProperty("category_name")
+    private String categoryName;
+
+    @JsonProperty("place_name")
+    private String placeName;
+
+    @JsonProperty("place_id")
+    private String placeId;
+
+    @JsonProperty("address_name")
+    private String addressName;
+
+    @JsonProperty("road_address_name")
+    private String roadAddressName;
+
+    @JsonProperty("review_score")
+    private Long reviewScore;
+
+    @JsonProperty("review_count")
+    private Long reviewCount;
+
+    @JsonProperty("avg_review_score")
+    private double avgReviewScore;
+
+
+    public static double calculateAvgScore(Long reviewScore, Long reviewCount) {
+
+        if (reviewScore == null || reviewScore == 0L) {
+            return 0;
+        }
+
+        if (reviewCount == null || reviewCount == 0L) {
+            return 0;
+        }
+
+        return (double) reviewScore / reviewCount;
+    }
+
+    public void setAvgReviewScore(double avgReviewScore) {
+        this.avgReviewScore = avgReviewScore;
+    }
+
+}

--- a/src/main/java/com/dateplanner/place/repository/PlaceRecommendationRepository.java
+++ b/src/main/java/com/dateplanner/place/repository/PlaceRecommendationRepository.java
@@ -1,0 +1,79 @@
+package com.dateplanner.place.repository;
+
+import com.dateplanner.place.dto.PlaceRecommendationDto;
+import com.dateplanner.place.entity.QCategory;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.dateplanner.place.entity.QCategory.category;
+import static com.dateplanner.place.entity.QPlace.place;
+import static org.springframework.util.StringUtils.hasText;
+
+@Repository
+public class PlaceRecommendationRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    public PlaceRecommendationRepository(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+
+    // TODO : 현재 리뷰 데이터가 많지 않아서 단순 평점만으로 정렬하기에는 다소 엉성한 감이 있다.
+    //  데이터가 많이 쌓일 경우 리뷰 횟수에도 조건을 두어 평점의 신뢰도를 조금이라도 높이는 것이 좋을 듯 하다.
+    public List<PlaceRecommendationDto> placeRecommendation(@Param("region1") String region1,
+                                                            @Param("region2") String region2,
+                                                            @Param("region3") String region3) {
+
+        NumberExpression<Long> avgReviewScorePath = place.reviewScore.divide(place.reviewCount);
+
+        return jpaQueryFactory
+                .select(Projections.fields(PlaceRecommendationDto.class,
+                        place.id.as("id"),
+                        category.id.as("categoryGroupId"),
+                        category.categoryName.as("categoryName"),
+                        place.placeName.as("placeName"),
+                        place.placeId.as("placeId"),
+                        place.addressName.as("addressName"),
+                        place.roadAddressName.as("roadAddressName"),
+                        place.reviewScore.as("reviewScore"),
+                        place.reviewCount.as("reviewCount")
+                        ))
+                .from(place)
+                .leftJoin(place.category, category)
+                .where(
+                        recommendationCondition(region1, region2, region3)
+                )
+                .orderBy(avgReviewScorePath.desc())
+                .limit(50)
+                .fetch();
+    }
+
+    private BooleanExpression region1Eq(String region1) {
+        return hasText(region1) ? place.region1DepthName.eq(region1) : null;
+    }
+
+    private BooleanExpression region2Eq(String region2) {
+        return hasText(region2) ? place.region2DepthName.eq(region2) : null;
+    }
+
+    private BooleanExpression region3Cont(String region3) {
+        return hasText(region3) ? place.region3DepthName.startsWith(region3) : null;
+    }
+    
+    private BooleanExpression categoryEq(String category) {
+        return hasText(category) ? QCategory.category.id.eq(category) : null;
+    }
+
+    private BooleanExpression recommendationCondition(String region1, String region2, String region3) {
+        return region1Eq(region1).and(region2Eq(region2)).and(region3Cont(region3));
+    }
+
+}

--- a/src/main/java/com/dateplanner/place/service/PlaceRecommendationService.java
+++ b/src/main/java/com/dateplanner/place/service/PlaceRecommendationService.java
@@ -1,0 +1,45 @@
+package com.dateplanner.place.service;
+
+import com.dateplanner.advice.exception.SearchResultNotFoundException;
+import com.dateplanner.api.PaginationService;
+import com.dateplanner.place.dto.PlaceRecommendationDto;
+import com.dateplanner.place.repository.PlaceRecommendationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j(topic = "SERVICE")
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class PlaceRecommendationService {
+
+    private final PlaceRecommendationRepository placeRecommendationRepository;
+    private final PaginationService paginationService;
+
+
+    public Page<PlaceRecommendationDto> getPlaceRecommendation(String region1, String region2, String region3, Pageable pageable) {
+
+        List<PlaceRecommendationDto> result = placeRecommendationRepository.placeRecommendation(region1, region2, region3);
+
+        if (Objects.isNull(result) || result.isEmpty()) {
+            log.error("[PlaceRecommendationService getPlaceRecommendation] recommendation result is null");
+            throw new SearchResultNotFoundException();
+        }
+
+        for (PlaceRecommendationDto dto : result) {
+            double avgScore = PlaceRecommendationDto.calculateAvgScore(dto.getReviewScore(), dto.getReviewCount());
+            dto.setAvgReviewScore(avgScore);
+        }
+
+        return paginationService.listToPage(result, pageable);
+
+    }
+
+}


### PR DESCRIPTION
사용자가 직접 주소와 카테고리를 입력해서 검색하는 장소 검색 기능 외에
사용자가 선택한 주소 (시/도, 군/구, 동/읍/면) + 리뷰 평점 기준으로 카테고리 구분 없이 상위 50개의 장소를 노출하는 지역별 명소 추천 기능을 추가한다

* [x] 컨트롤러 추가
* [x] 서비스 추가 및 조회 기능 구현
* [x] Querydsl 기반 리포지토리 추가, 조회 기능 구현

This closes #47 