### PR TITLE
[BE] Chrome 및 Selenium Docker Container 관련 세팅

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
 FROM openjdk:11
+WORKDIR /usr/src
+RUN apt-get -y update
+RUN apt install wget
+RUN apt install unzip
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN apt -y install ./google-chrome-stable_current_amd64.deb
+RUN wget -O /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/` curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE`/chromedriver_linux64.zip
+RUN mkdir chrome
+RUN unzip /tmp/chromedriver.zip chromedriver -d /usr/src/chrome
+WORKDIR /
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} ./app.jar
 ENV TZ=Asia/Seoul

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - "81:8084" # 기본 포트
     volumes:
       - /home/mrcocoball/date_planner/image:/home/mrcocoball/date_planner/image
+      #- /opt/chromedriver:/opt/chromedriver:ro
       # 호스트 경로 : 컨테이너 내부 경로 mount(연결) (해당 내용 지정 안할 경우 컨테이너 내부의 경로에만 저장이 됨)
     restart: always # depends on은 실행 순서만 컨트롤, 컨테이너 안의 서비스가 실행 가능한 상태인지는 확인하지 않으므로
     # DB가 실행 가능한 상태가 아니여서 실패할 경우 재시작하도록 설정

--- a/src/main/java/com/dateplanner/admin/place/service/PlaceCrawlingService.java
+++ b/src/main/java/com/dateplanner/admin/place/service/PlaceCrawlingService.java
@@ -106,7 +106,10 @@ public class PlaceCrawlingService {
         ChromeOptions chromeOptions = new ChromeOptions()
                 .addArguments("--start-maximized")
                 .addArguments("--disable-popup-blocking")
-                .addArguments("headless");
+                .addArguments("--single-process") // docker 환경용 추가
+                .addArguments("--disable-dev-shm-usage") // docker 환경용 추가
+                .addArguments("--no-sandbox") // docker 환경용 추가
+                .addArguments("--headless"); // 문법 수정
 
         WebDriver webDriver = new ChromeDriver(chromeOptions);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    active: local
+    active: dev
     group:
       local:
         - common
@@ -149,6 +149,6 @@ com:
     upload:
       path: /home/mrcocoball/date_planner/image
     webdriver:
-      path: /home/mrcocoball/date_planner/chromedriver
+      path: /usr/src/chrome/chromedriver
 
 ---

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   profiles:
-    active: dev
+    active: local
     group:
       local:
         - common


### PR DESCRIPTION
로컬 환경이 아닌 백엔드 API 서버 환경에서 Chrome 및 Selenium을 설치, 실행하는데 오류가 발생하여 (버전 이슈 등)
Chrome, Selenium이 같이 묶인 Docker Image를 활용, 애플리케이션 빌드 시 같이 컨테이너 내부에 설치, 실행되게끔 세팅하였다.
추가적으로, 로컬 환경은 Windows여서 충돌이 발생하지 않고 있었으나 Linux 환경에서 Chrome Options 관련 충돌이 발생하여 일부 옵션을 추가하였다.

* [x] Dockerfile 변경
* [x] Chrome Options 변경
* [x] 테스트

This closes #63 