### PR TITLE
[BE] 어드민 페이지 권한 처리

### DIFF
--- a/src/main/java/com/dateplanner/admin/auth/controller/AdminController.java
+++ b/src/main/java/com/dateplanner/admin/auth/controller/AdminController.java
@@ -1,0 +1,38 @@
+package com.dateplanner.admin.auth.controller;
+
+import com.dateplanner.admin.auth.service.AdminJoinService;
+import com.dateplanner.api.model.SingleResult;
+import com.dateplanner.api.service.ResponseService;
+import com.dateplanner.security.dto.TokenDto;
+import com.dateplanner.user.dto.UserLoginRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j(topic = "CONTROLLER")
+@RequiredArgsConstructor
+@Controller
+@RequestMapping("/admin")
+public class AdminController {
+
+    private final AdminJoinService adminJoinService;
+    private final ResponseService responseService;
+
+    @GetMapping("/login")
+    public String loginGet() {
+		return "admin/login";
+    }
+
+    @ResponseBody
+    @PostMapping("/login")
+    public SingleResult<TokenDto> adminLogin(UserLoginRequestDto dto) {
+
+        log.info("email = {}", dto.getEmail());
+
+        TokenDto tokenDto = adminJoinService.adminLogin(dto);
+
+        return responseService.getSingleResult(tokenDto);
+    }
+
+}

--- a/src/main/java/com/dateplanner/admin/auth/service/AdminJoinService.java
+++ b/src/main/java/com/dateplanner/admin/auth/service/AdminJoinService.java
@@ -1,0 +1,70 @@
+package com.dateplanner.admin.auth.service;
+
+import com.dateplanner.advice.exception.PasswordMismatchException;
+import com.dateplanner.advice.exception.UserNotFoundApiException;
+import com.dateplanner.security.dto.TokenDto;
+import com.dateplanner.security.entity.RefreshToken;
+import com.dateplanner.security.jwt.JwtProvider;
+import com.dateplanner.security.repository.RefreshTokenRepository;
+import com.dateplanner.user.dto.UserLoginRequestDto;
+import com.dateplanner.user.entity.User;
+import com.dateplanner.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j(topic = "SERVICE")
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class AdminJoinService {
+
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+    private final PasswordEncoder passwordEncoder;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+
+    // TODO : 현재 모듈이 분리되어 있지 않아 임시로 JWT 로그인 방식 진행, 모듈 분리 이후에는 폼 로그인 방식으로 변경
+
+    public TokenDto adminLogin(UserLoginRequestDto dto) {
+
+        // 회원 정보 조회
+        User user = userRepository.findByEmail(dto.getEmail()).orElseThrow(UserNotFoundApiException::new);
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword()))
+            throw new PasswordMismatchException();
+
+        log.info("user role={}", user.getRoleSet().get(0));
+
+        // 권한 검증
+        if (!user.getRoleSet().get(0).equals("ROLE_ADMIN")) {
+            throw new AccessDeniedException("need Admin Authority");
+        }
+
+        // 액세스 토큰, 리프레시 토큰 발급
+        log.info("create token start");
+        TokenDto tokenDto = jwtProvider.createToken(user.getEmail(), user.getRoleSet());
+        log.info("create token complete");
+
+        // 리프레시 토큰 저장
+        log.info("refresh token persist start");
+        log.info("key : {}, token : {}", user.getEmail(), tokenDto.getRefreshToken());
+        RefreshToken refreshToken = RefreshToken.builder()
+                .key(user.getEmail())
+                .token(tokenDto.getRefreshToken())
+                .build();
+
+        if (refreshTokenRepository.findByKey(user.getEmail()).isPresent())
+            refreshTokenRepository.deleteByKey(user.getEmail());
+        refreshTokenRepository.save(refreshToken);
+        log.info("refresh token persist complete");
+
+        return tokenDto;
+    }
+
+}

--- a/src/main/java/com/dateplanner/admin/consumer/controller/AnnouncementAdminController.java
+++ b/src/main/java/com/dateplanner/admin/consumer/controller/AnnouncementAdminController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -33,6 +34,7 @@ public class AnnouncementAdminController {
      */
 
     @GetMapping()
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getAnnouncementList(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                                       ModelMap map) {
 
@@ -46,6 +48,7 @@ public class AnnouncementAdminController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getAnnouncement(@PathVariable("id") Long id, ModelMap map) {
 
         AnnouncementDto dto = announcementService.getAnnouncement(id);
@@ -56,6 +59,7 @@ public class AnnouncementAdminController {
     }
 
     @GetMapping("/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getWriteForm(ModelMap map) {
 
         List<AnnouncementCategoryDto> categories = announcementService.getAnnouncementCategoryList();
@@ -65,6 +69,7 @@ public class AnnouncementAdminController {
     }
 
     @PostMapping("/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String writeAnnouncement(@Valid AnnouncementRequestDto dto,
                                     BindingResult r, RedirectAttributes ra) {
 
@@ -84,6 +89,7 @@ public class AnnouncementAdminController {
     }
 
     @GetMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getModifyForm(@PathVariable("id") Long id, ModelMap map) {
 
         List<AnnouncementCategoryDto> categories = announcementService.getAnnouncementCategoryList();
@@ -96,6 +102,7 @@ public class AnnouncementAdminController {
     }
 
     @PostMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyAnnouncement(@PathVariable("id") Long id,
                                      @Valid AnnouncementModifyRequestDto dto,
                                      BindingResult r, RedirectAttributes ra) {
@@ -116,6 +123,7 @@ public class AnnouncementAdminController {
     }
 
     @PostMapping("/{id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deleteAnnouncement(@PathVariable("id") Long id) {
 
         announcementService.deleteAnnouncement(id);
@@ -130,6 +138,7 @@ public class AnnouncementAdminController {
      */
 
     @GetMapping("/categories")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getAnnouncementCategoryList(ModelMap map) {
 
         List<AnnouncementCategoryDto> dtos = announcementService.getAnnouncementCategoryList();
@@ -140,6 +149,7 @@ public class AnnouncementAdminController {
     }
 
     @GetMapping("/categories/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getAnnouncementCategory(@PathVariable("id") Long id, ModelMap map) {
 
         AnnouncementCategoryDto dto = announcementService.getAnnouncementCategory(id);
@@ -150,12 +160,14 @@ public class AnnouncementAdminController {
     }
 
     @GetMapping("/categories/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getCategoryWriteForm() {
 
         return "admin/service/announcements/announcements_category_write";
     }
 
     @PostMapping("/categories/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String writeAnnouncementCategory(@Valid AnnouncementCategoryRequestDto dto,
                                             BindingResult r, RedirectAttributes ra) {
 
@@ -175,6 +187,7 @@ public class AnnouncementAdminController {
     }
 
     @GetMapping("/categories/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getCategoryModifyForm(@PathVariable("id") Long id, ModelMap map) {
 
         AnnouncementCategoryModifyRequestDto dto = AnnouncementCategoryModifyRequestDto.from(announcementService.getAnnouncementCategory(id));
@@ -185,6 +198,7 @@ public class AnnouncementAdminController {
     }
 
     @PostMapping("/categories/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyAnnouncementCategory(@PathVariable("id") Long id,
                                              @Valid AnnouncementCategoryModifyRequestDto dto,
                                              BindingResult r, RedirectAttributes ra) {
@@ -205,6 +219,7 @@ public class AnnouncementAdminController {
     }
 
     @PostMapping("/categories/{id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deleteAnnouncementCategory(@PathVariable("id") Long id) {
 
         announcementService.deleteAnnouncementCategory(id);

--- a/src/main/java/com/dateplanner/admin/consumer/controller/FaqAdminController.java
+++ b/src/main/java/com/dateplanner/admin/consumer/controller/FaqAdminController.java
@@ -5,6 +5,7 @@ import com.dateplanner.admin.consumer.service.FaqService;
 import com.dateplanner.common.pagination.PaginationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -31,6 +32,7 @@ public class FaqAdminController {
      */
 
     @GetMapping
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getFavoriteQuestionCategoryList(ModelMap map) {
 
         List<FavoriteQuestionCategoryDto> dtos = faqService.getFavoriteQuestionCategoryList();
@@ -40,6 +42,7 @@ public class FaqAdminController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getFavoriteQuestionCategory(@PathVariable("id") Long id, ModelMap map) {
 
         FavoriteQuestionCategoryDto dto = faqService.getFavoriteQuestionCategory(id);
@@ -50,12 +53,14 @@ public class FaqAdminController {
     }
 
     @GetMapping("/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getCategoryWriteForm() {
 
         return "admin/service/faq/faq_write";
     }
 
     @PostMapping("/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String writeFavoriteQuestionCategory(@Valid FavoriteQuestionCategoryRequestDto dto, BindingResult r, RedirectAttributes ra) {
 
         if (r.hasErrors()) {
@@ -73,6 +78,7 @@ public class FaqAdminController {
     }
 
     @GetMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getCategoryModifyForm(@PathVariable("id") Long id, ModelMap map) {
 
         FavoriteQuestionCategoryModifyRequestDto dto = FavoriteQuestionCategoryModifyRequestDto.from(faqService.getFavoriteQuestionCategory(id));
@@ -82,6 +88,7 @@ public class FaqAdminController {
     }
 
     @PostMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyFavoriteQuestionCategory(@PathVariable("id") Long id,
                                                  @Valid FavoriteQuestionCategoryModifyRequestDto dto,
                                                  BindingResult r, RedirectAttributes ra) {
@@ -101,6 +108,7 @@ public class FaqAdminController {
     }
 
     @PostMapping("/{id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deleteFavoriteQuestionCategory(@PathVariable("id") Long id) {
 
         faqService.deleteFavoriteQuestionCategory(id);
@@ -115,6 +123,7 @@ public class FaqAdminController {
      */
 
     @GetMapping("/answers/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getFavoriteAnswer(@PathVariable("id") Long id, ModelMap map) {
 
         FavoriteAnswerDto dto = faqService.getFavoriteAnswer(id);
@@ -125,6 +134,7 @@ public class FaqAdminController {
     }
 
     @GetMapping("/answers/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getAnswerWriteForm(ModelMap map) {
 
         List<FavoriteQuestionCategoryDto> categories = faqService.getFavoriteQuestionCategoryList();
@@ -134,6 +144,7 @@ public class FaqAdminController {
     }
 
     @PostMapping("/answers/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String writeFavoriteAnswer(@Valid FavoriteAnswerRequestDto dto, BindingResult r, RedirectAttributes ra) {
 
         if (r.hasErrors()) {
@@ -151,6 +162,7 @@ public class FaqAdminController {
     }
 
     @GetMapping("/answers/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getAnswerModifyForm(@PathVariable("id") Long id, ModelMap map) {
 
         FavoriteAnswerModifyRequestDto dto = FavoriteAnswerModifyRequestDto.from(faqService.getFavoriteAnswer(id));
@@ -160,6 +172,7 @@ public class FaqAdminController {
     }
 
     @PostMapping("/answers/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyFavoriteAnswer(@PathVariable("id") Long id,
                                        @Valid FavoriteAnswerModifyRequestDto dto,
                                        BindingResult r, RedirectAttributes ra) {
@@ -179,6 +192,7 @@ public class FaqAdminController {
     }
 
     @PostMapping("/answers/{id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deleteFavoriteAnswer(@PathVariable("id") Long id) {
 
         faqService.deleteFavoriteAnswer(id);

--- a/src/main/java/com/dateplanner/admin/consumer/controller/QnaAdminController.java
+++ b/src/main/java/com/dateplanner/admin/consumer/controller/QnaAdminController.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -37,6 +38,7 @@ public class QnaAdminController {
      */
 
     @GetMapping
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getQuestionList(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                                   ModelMap map) {
 
@@ -50,6 +52,7 @@ public class QnaAdminController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getQuestion(@PathVariable("id") Long id, ModelMap map) {
 
         QuestionDto dto = qnaService.getQuestion(id);
@@ -60,6 +63,7 @@ public class QnaAdminController {
     }
 
     @GetMapping("/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getWriteForm(ModelMap map) {
 
         List<QuestionCategoryDto> categories = qnaService.getQuestionCategoryList();
@@ -70,6 +74,7 @@ public class QnaAdminController {
     }
 
     @PostMapping("/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String writeQuestion(@Valid QuestionRequestDto dto,
                                 BindingResult r,
                                 RedirectAttributes ra,
@@ -95,6 +100,7 @@ public class QnaAdminController {
     }
 
     @GetMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getModifyForm(@PathVariable("id") Long id, ModelMap map) {
 
         QuestionModifyRequestDto dto = QuestionModifyRequestDto.from(qnaService.getQuestion(id));
@@ -107,6 +113,7 @@ public class QnaAdminController {
     }
 
     @PostMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyQuestion(@PathVariable("id") Long id,
                                  @Valid QuestionModifyRequestDto dto,
                                  BindingResult r,
@@ -127,6 +134,7 @@ public class QnaAdminController {
     }
 
     @PostMapping("{/id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deleteQuestion(@PathVariable("id") Long id) {
 
         qnaService.deleteQuestion(id);
@@ -141,6 +149,7 @@ public class QnaAdminController {
      */
 
     @PostMapping("/answers/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String writeAnswer(@Valid AnswerRequestDto dto,
                               BindingResult r,
                               RedirectAttributes ra,
@@ -166,6 +175,7 @@ public class QnaAdminController {
     }
 
     @PostMapping("/answers/{id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deleteAnswer(@PathVariable("id") Long id, Long qid) {
 
         qnaService.deleteAnswer(id);
@@ -180,6 +190,7 @@ public class QnaAdminController {
      */
 
     @GetMapping("/categories")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getQuestionCategoryList(ModelMap map) {
 
         List<QuestionCategoryDto> dtos = qnaService.getQuestionCategoryList();
@@ -190,6 +201,7 @@ public class QnaAdminController {
     }
 
     @GetMapping("/categories/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getQuestionCategory(@PathVariable("id") Long id, ModelMap map) {
 
         QuestionCategoryDto dto = qnaService.getQuestionCategory(id);
@@ -200,6 +212,7 @@ public class QnaAdminController {
     }
 
     @GetMapping("/categories/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getCategoryWriteForm() {
 
         return "admin/service/qna/qna_category_write";
@@ -207,6 +220,7 @@ public class QnaAdminController {
     }
 
     @PostMapping("/categories/write")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String writeQuestionCategory(@Valid QuestionCategoryRequestDto dto,
                                         BindingResult r,
                                         RedirectAttributes ra) {
@@ -227,6 +241,7 @@ public class QnaAdminController {
     }
 
     @GetMapping("/categories/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getCategoryModifyForm(@PathVariable("id") Long id, ModelMap map) {
 
         QuestionCategoryModifyRequestDto dto = QuestionCategoryModifyRequestDto.from(qnaService.getQuestionCategory(id));
@@ -237,6 +252,7 @@ public class QnaAdminController {
     }
 
     @PostMapping("/categories/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyQuestionCategory(@PathVariable("id") Long id,
                                          @Valid QuestionCategoryModifyRequestDto dto,
                                          BindingResult r,
@@ -257,6 +273,7 @@ public class QnaAdminController {
     }
 
     @PostMapping("/categories/{id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deleteQuestionCategory(@PathVariable("id") Long id) {
 
         qnaService.deleteQuestionCategory(id);

--- a/src/main/java/com/dateplanner/admin/place/controller/PlaceAdminApiController.java
+++ b/src/main/java/com/dateplanner/admin/place/controller/PlaceAdminApiController.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,6 +36,7 @@ public class PlaceAdminApiController {
     @Operation(summary = "[GET] 이미지 URL이 추가가 되지 않은 장소 조회",
             description = "DB에 생성이 되었으나 이미지 URL이 추가 되지 않은 장소(이미지 URL이 NULL인 장소)들을 조회합니다.")
     @GetMapping("/api/v1/admin/nullPlaces")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public PageResult<PlaceStatusDto> getImageUrlNullPlacesV1(@ParameterObject @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
 
         return responseService.getPageResult(placeAdminService.getImageUrlNullPlacesV1(pageable));
@@ -45,6 +47,7 @@ public class PlaceAdminApiController {
     @Operation(summary = "[GET] 이미지 URL 업데이트를 진행하였으나 이미지가 존재하지 않은 장소 조회",
             description = "이미지 URL 업데이트를 진행하였으나 원본 장소의 이미지가 존재하지 않아 추가를 하지 못했던 장소들을 조회합니다.")
     @GetMapping("/api/v1/admin/notExistPlaces")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public PageResult<PlaceStatusDto> getImageUrlNotExistPlacesV1(@ParameterObject @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
 
         return responseService.getPageResult(placeAdminService.getImageUrlNotExistPlacesV1(pageable));
@@ -56,6 +59,7 @@ public class PlaceAdminApiController {
             description = "이미지 URL이 추가되지 않은 장소들을 조회한 뒤 해당 장소들에 대해 크롤링을 요청하고 크롤링 결과를 조회합니다. <br>" +
                     "실제 DB 장소에는 저장되지는 않습니다.")
     @PostMapping("/api/v1/admin/crawling")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public PageResult<PlaceCrawlingDto> crawlingPlacesV1(@ParameterObject @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
 
         return responseService.getPageResult(placeCrawlingService.searchAndCrawling(pageable));
@@ -66,6 +70,7 @@ public class PlaceAdminApiController {
             description = "이미지 URL이 추가되지 않은 장소들을 조회한 뒤 해당 장소들에 대해 크롤링을 요청하고 <br>" +
                     "크롤링된 정보를 토대로 장소 정보를 업데이트합니다. 업데이트된 장소의 개수가 반환됩니다.")
     @PostMapping("/api/v1/admin/crawlingAndUpdate")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public SingleResult<Long> crawlingAndUpdatePlacesV1() {
 
         List<PlaceCrawlingDto> dtos = placeCrawlingService.searchAndCrawling();

--- a/src/main/java/com/dateplanner/admin/place/controller/PlaceAdminController.java
+++ b/src/main/java/com/dateplanner/admin/place/controller/PlaceAdminController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -32,6 +33,7 @@ public class PlaceAdminController {
     private final PaginationService paginationService;
 
     @GetMapping()
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getPlaceList(@RequestParam(required = false) String region1, @RequestParam(required = false) String region2, @RequestParam(required = false) String region3,
                                @RequestParam(required = false) String categoryId, @RequestParam(required = false) Long id,
                                @RequestParam(required = false) String placeId, @RequestParam(required = false) String placeName, @RequestParam(required = false) Long reviewCount,
@@ -49,6 +51,7 @@ public class PlaceAdminController {
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getPlace(@PathVariable("id") Long id, ModelMap map) {
 
         PlaceAdminDetailDto dto = placeAdminService.getPlace(id);
@@ -58,6 +61,7 @@ public class PlaceAdminController {
     }
 
     @GetMapping("/create")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String createPlaceForm() {
 
         return "admin/places/places_create";
@@ -65,6 +69,7 @@ public class PlaceAdminController {
     }
 
     @PostMapping("/create")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String createPlace(@Valid PlaceRequestDto dto,
                              BindingResult r,
                              RedirectAttributes ra) {
@@ -85,6 +90,7 @@ public class PlaceAdminController {
     }
 
     @GetMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyPlaceForm(@PathVariable("id") Long id, ModelMap map) {
 
         PlaceModifyRequestDto dto = PlaceModifyRequestDto.from(placeAdminService.getPlace(id));
@@ -95,6 +101,7 @@ public class PlaceAdminController {
     }
 
     @PostMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyPlace(@PathVariable("id") Long id,
                              @Valid PlaceModifyRequestDto dto,
                              BindingResult r,
@@ -116,6 +123,7 @@ public class PlaceAdminController {
     }
 
     @PostMapping("/{id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deletePlace(@PathVariable("id") Long id) {
 
         placeAdminService.deletePlace(id);

--- a/src/main/java/com/dateplanner/admin/user/controller/UserAdminController.java
+++ b/src/main/java/com/dateplanner/admin/user/controller/UserAdminController.java
@@ -78,8 +78,8 @@ public class UserAdminController {
 
 
     // @PreAuthorize("isAuthenticated()")
-    @GetMapping("/{id}")
-    public String getUserByUid(@PathVariable("id") Long uid, ModelMap map) {
+    @GetMapping("/{uid}")
+    public String getUserByUid(@PathVariable("uid") Long uid, ModelMap map) {
 
         UserResponseDto dto = userAdminService.getUserByUid(uid);
         map.addAttribute("dto", dto);

--- a/src/main/java/com/dateplanner/admin/user/controller/UserAdminController.java
+++ b/src/main/java/com/dateplanner/admin/user/controller/UserAdminController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -30,13 +31,12 @@ import java.util.List;
 @RequestMapping("/admin/users")
 public class UserAdminController {
 
-
     private final UserAdminService userAdminService;
     private final PaginationService paginationService;
 
 
-    // @PreAuthorize("isAuthenticated()")
     @GetMapping()
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getUserList(@RequestParam(required = false) String email,
                               @RequestParam(required = false) String nickname,
                               @RequestParam(required = false) boolean deleted,
@@ -57,8 +57,8 @@ public class UserAdminController {
         return "admin/users/users";
     }
 
-    // @PreAuthorize("isAuthenticated()")
     @GetMapping("/deleted")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getDeletedUserList(@RequestParam(required = false) String email,
                                      @RequestParam(required = false) String nickname,
                                      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -77,8 +77,8 @@ public class UserAdminController {
     }
 
 
-    // @PreAuthorize("isAuthenticated()")
     @GetMapping("/{uid}")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getUserByUid(@PathVariable("uid") Long uid, ModelMap map) {
 
         UserResponseDto dto = userAdminService.getUserByUid(uid);
@@ -88,16 +88,16 @@ public class UserAdminController {
     }
 
 
-    // @PreAuthorize("isAuthenticated()")
     @GetMapping("/create")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String createUserForm() {
 
         return "admin/users/users_create";
 
     }
 
-    // @PreAuthorize("isAuthenticated()")
     @PostMapping("/create")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String createUser(@Valid UserRequestDto dto,
                              BindingResult r,
                              RedirectAttributes ra) {
@@ -117,8 +117,8 @@ public class UserAdminController {
 
     }
 
-    // @PreAuthorize("isAuthenticated()")
     @GetMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyUserForm(@PathVariable("id") Long uid, ModelMap map) {
 
         UserModifyRequestDto dto = UserModifyRequestDto.from(userAdminService.getUserByUid(uid));
@@ -128,8 +128,8 @@ public class UserAdminController {
 
     }
 
-    // @PreAuthorize("isAuthenticated()")
     @PostMapping("/{id}/modify")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String modifyUser(@PathVariable("id") Long uid,
                              @Valid UserModifyRequestDto dto,
                              BindingResult r,
@@ -150,8 +150,8 @@ public class UserAdminController {
 
     }
 
-    // @PreAuthorize("isAuthenticated()")
     @PostMapping("/{id}/delete")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String deleteUser(@Parameter(description = "회원 ID", required = true) @PathVariable("id") Long uid) {
 
         userAdminService.deleteUser(uid);
@@ -166,6 +166,7 @@ public class UserAdminController {
      */
 
     @GetMapping("/passwordRequests")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     public String getUserPasswordRequestList(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                                              ModelMap map) {
 

--- a/src/main/java/com/dateplanner/user/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/dateplanner/user/dto/UserLoginRequestDto.java
@@ -2,11 +2,13 @@ package com.dateplanner.user.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.Setter;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 @Getter
+@Setter
 public class UserLoginRequestDto {
 
     @Schema(description = "회원 이메일")

--- a/src/main/resources/static/css/signin.css
+++ b/src/main/resources/static/css/signin.css
@@ -1,0 +1,43 @@
+html,
+body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  align-items: center;
+  padding-top: 40px;
+  padding-bottom: 40px;
+  background-color: #f5f5f5;
+}
+
+.form-signin {
+  max-width: 330px;
+  padding: 15px;
+}
+
+.form-signin .form-floating:focus-within {
+  z-index: 2;
+}
+
+.form-signin input[type="username"] {
+  margin-bottom: -1px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.form-signin input[type="password"] {
+  margin-bottom: 10px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.form-signin input[type="email"] {
+  margin-bottom: 10px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.error-messages > p {
+    color: crimson;
+}

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, shrink-to-fit=no"/>
+  <meta name="description" content=""/>
+  <meta name="author" content=""/>
+  <title>어드민 로그인 페이지</title>
+  <!-- Favicon-->
+  <link rel="icon" type="image/x-icon" th:href="@{/assets/favicon.ico}"/>
+  <!-- Core theme CSS (includes Bootstrap)-->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  <link href="/css/layout.css" rel="stylesheet">
+  <link href="/css/signin.css" rel="stylesheet">
+</head>
+<body class="text-center">
+
+<main class="form-signin w-100 m-auto">
+  <h1 class="h3 mb-3 fw-normal">Please sign in</h1>
+  <th:block th:if="${param.error}">
+    <p class="error-message" style="color: crimson" th:text="${errorMessage}">로그인 실패!</p>
+  </th:block>
+  <form id="registerForm" action="/admin/login" method="post">
+    <div class="form-floating">
+      <input type="text" class="form-control" name="email" id="floatingInput" placeholder="이메일">
+      <label for="floatingInput">아이디</label>
+    </div>
+    <div class="form-floating">
+      <input type="password" class="form-control" name="password" id="floatingPassword" placeholder="PASSWORD">
+      <label for="floatingPassword">비밀번호</label>
+    </div>
+
+    <button class="w-100 btn btn-lg btn-primary" type="submit">LOGIN</button>
+    <p class="mt-5 mb-3 text-muted">&copy; Cocoball Enterprise</p>
+  </form>
+</main>
+</body>
+</html>

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -7,8 +7,6 @@
   <meta name="description" content=""/>
   <meta name="author" content=""/>
   <title>어드민 로그인 페이지</title>
-  <!-- Favicon-->
-  <link rel="icon" type="image/x-icon" th:href="@{/assets/favicon.ico}"/>
   <!-- Core theme CSS (includes Bootstrap)-->
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
@@ -25,7 +23,7 @@
   <form id="registerForm" action="/admin/login" method="post">
     <div class="form-floating">
       <input type="text" class="form-control" name="email" id="floatingInput" placeholder="이메일">
-      <label for="floatingInput">아이디</label>
+      <label for="floatingInput">이메일</label>
     </div>
     <div class="form-floating">
       <input type="password" class="form-control" name="password" id="floatingPassword" placeholder="PASSWORD">
@@ -33,7 +31,7 @@
     </div>
 
     <button class="w-100 btn btn-lg btn-primary" type="submit">LOGIN</button>
-    <p class="mt-5 mb-3 text-muted">&copy; Cocoball Enterprise</p>
+    <p class="mt-5 mb-3 text-muted">&copy; 2023 Cocoball Enterprise</p>
   </form>
 </main>
 </body>

--- a/src/main/resources/templates/admin/users/users.html
+++ b/src/main/resources/templates/admin/users/users.html
@@ -24,10 +24,11 @@
           <option th:value="true" th:text="탈퇴" th:selected="${param.deleted == true}"></option>
         </select>
         <select name="social" id="social" form="dynamic-query-parameter-form">
-          <option th:value="true" th:selected="${param.social == true}">소셜 로그인 연동</option>
           <option th:value="false" th:selected="${param.social == false}">소셜 로그인 미연동</option>
+          <option th:value="true" th:selected="${param.social == true}">소셜 로그인 연동</option>
         </select>
         <select name="provider" id="provider" form="dynamic-query-parameter-form">
+          <option th:name="null" th:value="null">인증 제공</option>
           <option th:name="'kakao'" th:value="'kakao'" th:text="카카오"
                   th:selected="${param.provider eq 'kakao'}"></option>
           <option th:name="'naver'" th:value="'naver'" th:text="네이버"
@@ -49,6 +50,7 @@
         <th>회원 번호</th>
         <th>이메일</th>
         <th>닉네임</th>
+        <th>상세 정보</th>
         <th>탈퇴 여부</th>
         <th>소셜 로그인 연동</th>
         <th>생성일자</th>

--- a/src/main/resources/templates/admin/users/users_detail.html
+++ b/src/main/resources/templates/admin/users/users_detail.html
@@ -51,19 +51,19 @@
       <li class="list-group-item">
         <div>
           <h6>생성일자</h6>
-          <p class="createdAt" id="createdAt" th:text="${dto.createdAt}"></p>
+          <p class="createdAt" id="createdAt" th:text="${#temporals.format(dto.createdAt, 'yyyy-MM-dd HH:mm')}"></p>
         </div>
       </li>
       <li class="list-group-item">
         <div>
           <h6>수정일자</h6>
-          <p class="modifiedAt" id="modifiedAt" th:text="${dto.modifiedAt}"></p>
+          <p class="modifiedAt" id="modifiedAt" th:text="${#temporals.format(dto.modifiedAt, 'yyyy-MM-dd HH:mm')}"></p>
         </div>
       </li>
     </ul>
     <div class="reverse-align">
-      <form class="delete-form" th:action="'/admin/users/' + ${dto.id} + '/delete'" th:method="post">
-        <a th:href="@{'/admin/users/' + ${dto.id} + '/modify'}">
+      <form class="delete-form" th:action="'/admin/users/' + ${dto.uid} + '/delete'" th:method="post">
+        <a th:href="@{'/admin/users/' + ${dto.uid} + '/modify'}">
           <button type="button" class="btn btn-update">수정</button>
         </a>
         <button type="submit" class="btn btn-delete">삭제</button>

--- a/src/main/resources/templates/layout/basic.html
+++ b/src/main/resources/templates/layout/basic.html
@@ -63,8 +63,8 @@
       </ul>
 
       <div class="text-end">
-        <button sec:authorize="!isAuthenticated()" type="button" class="btn btn-outline-light me-2">로그인</button>
-        <button sec:authorize="isAuthenticated()" type="button" class="btn btn-dark me-2">로그아웃</button>
+        <button sec:authorize="!isAuthenticated()" type="button" onclick="location.href='/admin/login';" class="btn btn-outline-light me-2">로그인</button>
+        <button sec:authorize="isAuthenticated()" type="button" onclick="location.href='/admin/logout';" class="btn btn-dark me-2">로그아웃</button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
현재 어드민 페이지에 대한 권한 설정이 되어 있지 않다
어드민 권한을 설정하고 어드민 페이지에 대해 접근 권한을 부여한다
세션 방식 로그인을 적용하려 하였으나 어플리케이션 서버의 경우 JWT 로그인이 적용되어 있어
일단 모듈 분리 전까지는 임시로 JWT 로그인 방식을 적용하도록 한다

* [x] 어드민 권한 설정
* [x] 어드민 페이지 접근 권한 부여
* [x] 어드민 로그인 기능 / 페이지

This closes #86 