### PR TITLE
[BE] 페이징 정렬 기능 수정 및 동적 정렬 기능 추가

### DIFF
--- a/module-admin/src/main/java/dev/be/moduleadmin/place/service/PlaceCrawlingService.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/place/service/PlaceCrawlingService.java
@@ -2,7 +2,6 @@ package dev.be.moduleadmin.place.service;
 
 import dev.be.moduleadmin.place.dto.PlaceCrawlingDto;
 import dev.be.modulecore.repositories.support.PlaceAdminRepository;
-import dev.be.modulecore.service.PaginationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
@@ -12,8 +11,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
@@ -30,7 +27,6 @@ import java.util.StringJoiner;
 public class PlaceCrawlingService {
 
     private final PlaceAdminRepository placeAdminRepository;
-    private final PaginationService paginationService;
     private static final String BASE_URL = "https://place.map.kakao.com/";
     private static final String WEB_DRIVER_ID = "webdriver.chrome.driver";
 

--- a/module-admin/src/main/java/dev/be/moduleadmin/support/controller/AnnouncementAdminController.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/support/controller/AnnouncementAdminController.java
@@ -39,7 +39,7 @@ public class AnnouncementAdminController {
     public String getAnnouncementList(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                                       ModelMap map) {
 
-        Page<AnnouncementDto> dtos = paginationService.listToPage(announcementAdminService.getAnnouncementList(), pageable);
+        Page<AnnouncementDto> dtos = announcementAdminService.getAnnouncementList(pageable);
         List<Integer> pageBarNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), dtos.getTotalPages());
         map.addAttribute("dtos", dtos);
         map.addAttribute("pageBarNumbers", pageBarNumbers);

--- a/module-admin/src/main/java/dev/be/moduleadmin/support/controller/FaqAdminController.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/support/controller/FaqAdminController.java
@@ -2,7 +2,6 @@ package dev.be.moduleadmin.support.controller;
 
 import dev.be.moduleadmin.support.dto.*;
 import dev.be.moduleadmin.support.service.FaqAdminService;
-import dev.be.modulecore.service.PaginationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -24,7 +23,6 @@ import java.util.List;
 public class FaqAdminController {
 
     private final FaqAdminService faqAdminService;
-    private final PaginationService paginationService;
 
     /**
      * 카테고리 관련

--- a/module-admin/src/main/java/dev/be/moduleadmin/support/controller/QnaAdminController.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/support/controller/QnaAdminController.java
@@ -40,7 +40,7 @@ public class QnaAdminController {
     public String getQuestionList(@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
                                   ModelMap map) {
 
-        Page<QuestionDto> dtos = paginationService.listToPage(qnaAdminService.getQuestionList(), pageable);
+        Page<QuestionDto> dtos = qnaAdminService.getQuestionList(pageable);
         List<Integer> pageBarNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), dtos.getTotalPages());
         map.addAttribute("dtos", dtos);
         map.addAttribute("pageBarNumbers", pageBarNumbers);

--- a/module-admin/src/main/java/dev/be/moduleadmin/support/service/AnnouncementAdminService.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/support/service/AnnouncementAdminService.java
@@ -8,11 +8,12 @@ import dev.be.modulecore.repositories.support.AnnouncementAdminRepository;
 import dev.be.modulecore.repositories.support.AnnouncementCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,10 +32,9 @@ public class AnnouncementAdminService {
      */
 
     @Transactional(readOnly = true)
-    public List<AnnouncementDto> getAnnouncementList() {
+    public Page<AnnouncementDto> getAnnouncementList(Pageable pageable) {
 
-        return announcementAdminRepository.findAll().stream().map(AnnouncementDto::from)
-                        .sorted(Comparator.comparing(AnnouncementDto::getCreatedAt).reversed()).collect(Collectors.toList());
+        return announcementAdminRepository.findAll(pageable).map(announcement -> AnnouncementDto.from(announcement));
 
     }
 

--- a/module-admin/src/main/java/dev/be/moduleadmin/support/service/QnaAdminService.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/support/service/QnaAdminService.java
@@ -12,6 +12,8 @@ import dev.be.modulecore.repositories.support.QuestionCategoryRepository;
 import dev.be.modulecore.repositories.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,10 +38,9 @@ public class QnaAdminService {
      */
 
     @Transactional(readOnly = true)
-    public List<QuestionDto> getQuestionList() {
+    public Page<QuestionDto> getQuestionList(Pageable pageable) {
 
-        return questionAdminRepository.findAll().stream().map(QuestionDto::from)
-                .sorted(Comparator.comparing(QuestionDto::getCreatedAt).reversed()).collect(Collectors.toList());
+        return questionAdminRepository.findAll(pageable).map(question -> QuestionDto.from(question));
 
     }
 

--- a/module-admin/src/main/java/dev/be/moduleadmin/user/controller/UserAdminController.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/user/controller/UserAdminController.java
@@ -41,12 +41,12 @@ public class UserAdminController {
                               @RequestParam(required = false) String provider,
                               @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
                               @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
-                              @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+                              @PageableDefault(size = 10, sort = "modifiedAt", direction = Sort.Direction.DESC) Pageable pageable,
                               ModelMap map) {
 
 
         Page<UserResponseDto> dtos = paginationService.listToPage(
-                userAdminService.getUserList(email, nickname, deleted, social, provider, startDate, targetDate), pageable);
+                userAdminService.getUserList(email, nickname, deleted, social, provider, startDate, targetDate, pageable), pageable);
         List<Integer> pageBarNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), dtos.getTotalPages());
         map.addAttribute("dtos", dtos);
         map.addAttribute("pageBarNumbers", pageBarNumbers);
@@ -59,12 +59,12 @@ public class UserAdminController {
                                      @RequestParam(required = false) String nickname,
                                      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
                                      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate targetDate,
-                                     @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+                                     @PageableDefault(size = 10, sort = "modifiedAt", direction = Sort.Direction.DESC) Pageable pageable,
                                      ModelMap map) {
 
 
         Page<UserResponseDto> dtos = paginationService.listToPage(
-                userAdminService.getDeletedUserList(email, nickname, startDate, targetDate), pageable);
+                userAdminService.getDeletedUserList(email, nickname, startDate, targetDate, pageable), pageable);
         List<Integer> pageBarNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), dtos.getTotalPages());
         map.addAttribute("dtos", dtos);
         map.addAttribute("pageBarNumbers", pageBarNumbers);

--- a/module-admin/src/main/java/dev/be/moduleadmin/user/service/UserAdminService.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/user/service/UserAdminService.java
@@ -12,12 +12,15 @@ import dev.be.modulecore.repositories.support.UserAdminRepository;
 import dev.be.modulecore.repositories.support.UserPasswordRequestRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -40,11 +43,15 @@ public class UserAdminService {
                                              boolean social,
                                              String provider,
                                              LocalDate startDate,
-                                             LocalDate targetDate) {
+                                             LocalDate targetDate,
+                                             Pageable pageable) {
 
-        log.info("[UserAdminService getUserListByDQ] search condition : {}, {}, {}, {}, {}", deleted, social, provider, startDate, targetDate);
+        List<UserResponseDto> dtos = userAdminCustomRepository.userList(email, nickname, deleted, social, provider, startDate, targetDate).stream().collect(Collectors.toList());
 
-        return userAdminCustomRepository.userList(email, nickname, deleted, social, provider, startDate, targetDate).stream().collect(Collectors.toList());
+        if (pageable.getSort().equals(Sort.by(Sort.Direction.DESC, "modifiedAt"))) dtos.sort(Comparator.comparing(UserResponseDto::getModifiedAt).reversed());
+        if (pageable.getSort().equals(Sort.by(Sort.Direction.ASC, "modifiedAt"))) dtos.sort(Comparator.comparing(UserResponseDto::getModifiedAt));
+
+        return dtos;
 
     }
 
@@ -52,9 +59,15 @@ public class UserAdminService {
     public List<UserResponseDto> getDeletedUserList(String email,
                                                     String nickname,
                                                     LocalDate startDate,
-                                                    LocalDate targetDate) {
+                                                    LocalDate targetDate,
+                                                    Pageable pageable) {
 
-        return userAdminCustomRepository.deletedUserList(email, nickname,startDate, targetDate).stream().collect(Collectors.toList());
+        List<UserResponseDto> dtos = userAdminCustomRepository.deletedUserList(email, nickname, startDate, targetDate).stream().collect(Collectors.toList());
+
+        if (pageable.getSort().equals(Sort.by(Sort.Direction.DESC, "modifiedAt"))) dtos.sort(Comparator.comparing(UserResponseDto::getModifiedAt).reversed());
+        if (pageable.getSort().equals(Sort.by(Sort.Direction.ASC, "modifiedAt"))) dtos.sort(Comparator.comparing(UserResponseDto::getModifiedAt));
+
+        return dtos;
 
     }
 

--- a/module-api/src/main/java/dev/be/moduleapi/advice/CustomAdvice.java
+++ b/module-api/src/main/java/dev/be/moduleapi/advice/CustomAdvice.java
@@ -222,6 +222,13 @@ public class CustomAdvice {
                 (ErrorCode.ANNOUNCEMENT_NOT_FOUND.getCode(), ErrorCode.ANNOUNCEMENT_NOT_FOUND.getDescription());
     }
 
+    @ExceptionHandler(SortTypeInvalidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected CommonResult SortTypeInvalidException(HttpServletRequest request, SortTypeInvalidException e) {
+        return responseService.getFailResult
+                (ErrorCode.SORTTYPE_INVALID.getCode(), ErrorCode.SORTTYPE_INVALID.getDescription());
+    }
+
 
     /**
      * Data Access 관련

--- a/module-api/src/main/java/dev/be/moduleapi/advice/exception/SortTypeInvalidException.java
+++ b/module-api/src/main/java/dev/be/moduleapi/advice/exception/SortTypeInvalidException.java
@@ -1,0 +1,16 @@
+package dev.be.moduleapi.advice.exception;
+
+public class SortTypeInvalidException extends RuntimeException {
+
+    public SortTypeInvalidException() {
+        super();
+    }
+
+    public SortTypeInvalidException(String message) {
+        super(message);
+    }
+
+    public SortTypeInvalidException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/module-api/src/main/java/dev/be/moduleapi/bookmark/controller/BookmarkApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/bookmark/controller/BookmarkApiController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -72,7 +73,7 @@ public class BookmarkApiController {
     @GetMapping("/api/v1/bookmarks")
     public PageResult<BookmarkDto> getBookmarksV1(
             @Parameter(description = "요청한 유저의 인증 정보", required = true) Authentication authentication,
-            @ParameterObject @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         User user = (User) authentication.getPrincipal();
         String email = user.getEmail();

--- a/module-api/src/main/java/dev/be/moduleapi/bookmark/service/BookmarkApiService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/bookmark/service/BookmarkApiService.java
@@ -2,16 +2,12 @@ package dev.be.moduleapi.bookmark.service;
 
 import dev.be.moduleapi.bookmark.dto.BookmarkDto;
 import dev.be.modulecore.repositories.bookmark.BookmarkRepository;
-import dev.be.modulecore.service.PaginationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j(topic = "SERVICE")
 @RequiredArgsConstructor
@@ -20,7 +16,6 @@ import java.util.stream.Collectors;
 public class BookmarkApiService {
 
     private final BookmarkRepository bookmarkRepository;
-    private final PaginationService paginationService;
 
     public Page<BookmarkDto> getBookmarkList(String email, Pageable pageable) {
 
@@ -28,14 +23,14 @@ public class BookmarkApiService {
         long beforeTime = System.currentTimeMillis();
 
         log.info("[BookmarkApiService getBookmarkList] get bookmark list start...");
-        List<BookmarkDto> dtos = bookmarkRepository.findByUser_Email(email).stream().map(BookmarkDto::from).collect(Collectors.toList());
-        log.info("[BookmarkApiService getBookmarkList] get bookmark list complete, size : {}", dtos.size());
+        Page<BookmarkDto> dtos = bookmarkRepository.findByUser_Email(email, pageable).map(bookmark -> BookmarkDto.from(bookmark));
+        log.info("[BookmarkApiService getBookmarkList] get bookmark list complete, size : {}", dtos.getSize());
 
         // 인덱스 계산용 시간 측정
         long afterTime = System.currentTimeMillis();
         log.info("elapsed time : " + (afterTime-beforeTime));
 
-        return paginationService.listToPage(dtos, pageable);
+        return dtos;
     }
 
 }

--- a/module-api/src/main/java/dev/be/moduleapi/place/controller/PlaceRecommendationApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/place/controller/PlaceRecommendationApiController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -37,7 +38,7 @@ public class PlaceRecommendationApiController {
     public PageResult<PlaceRecommendationDto> getRecommendationV1(@Parameter(description = "시/도") @RequestParam(required = false) String region1,
                                                                   @Parameter(description = "군/구") @RequestParam(required = false) String region2,
                                                                   @Parameter(description = "동/읍/면") @RequestParam(required = false) String region3,
-                                                                  @ParameterObject @PageableDefault(size = 10, sort = "avgReviewScore") Pageable pageable) {
+                                                                  @ParameterObject @PageableDefault(size = 10, sort = "avgReviewScore", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return responseService.getPageResult(placeRecommendationService.getPlaceRecommendation(region1, region2, region3, pageable));
     }

--- a/module-api/src/main/java/dev/be/moduleapi/plan/service/PlanApiService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/plan/service/PlanApiService.java
@@ -4,7 +4,6 @@ import dev.be.moduleapi.advice.exception.PlanNotFoundApiException;
 import dev.be.moduleapi.plan.dto.PlanDto;
 import dev.be.modulecore.domain.plan.Plan;
 import dev.be.modulecore.repositories.plan.PlanRepository;
-import dev.be.modulecore.service.PaginationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,9 +12,6 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Slf4j(topic = "SERVICE")
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -23,16 +19,15 @@ import java.util.stream.Collectors;
 public class PlanApiService {
 
     private final PlanRepository planRepository;
-    private final PaginationService paginationService;
 
 
     public Page<PlanDto> getPlanListByNickname(String nickname, Pageable pageable) {
 
         log.info("[PlanApiService getPlanList] get plan list start...");
-        List<PlanDto> dtos = planRepository.findByUser_Nickname(nickname).stream().map(PlanDto::from).collect(Collectors.toList());
-        log.info("[PlanApiService getPlanList] get plan list complete, size : {}", dtos.size());
+        Page<PlanDto> dtos = planRepository.findByUser_Nickname(nickname, pageable).map(plan -> PlanDto.from(plan));
+        log.info("[PlanApiService getPlanList] get plan list complete, size : {}", dtos.getSize());
 
-        return paginationService.listToPage(dtos, pageable);
+        return dtos;
     }
 
     public PlanDto getPlan(Long id, String nickname) {

--- a/module-api/src/main/java/dev/be/moduleapi/review/controller/ReviewApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/review/controller/ReviewApiController.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -82,7 +83,7 @@ public class ReviewApiController {
     @GetMapping("/api/v1/reviews/list/{place_id}")
     public PageResult<ReviewDto> getReviewsByPlaceIdV1(
             @Parameter(description = "장소 ID", required = true) @PathVariable("place_id") String placeId,
-            @ParameterObject @PageableDefault(size = 5, sort = "createdAt") Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 5, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return responseService.getPageResult(reviewApiService.getReviewListByPlaceId(placeId, pageable));
     }
@@ -103,7 +104,7 @@ public class ReviewApiController {
     @GetMapping("/api/v1/reviews")
     public PageResult<ReviewDto> getReviewsByUserNicknameV1(
             @Parameter(description = "요청한 유저의 인증 정보", required = true) Authentication authentication,
-            @ParameterObject @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         User user = (User) authentication.getPrincipal();
         String nickname = user.getNickname();

--- a/module-api/src/main/java/dev/be/moduleapi/review/service/ReviewApiService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/review/service/ReviewApiService.java
@@ -3,16 +3,12 @@ package dev.be.moduleapi.review.service;
 import dev.be.moduleapi.advice.exception.ReviewNotFoundApiException;
 import dev.be.moduleapi.review.dto.ReviewDto;
 import dev.be.modulecore.repositories.review.ReviewRepository;
-import dev.be.modulecore.service.PaginationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j(topic = "SERVICE")
 @RequiredArgsConstructor
@@ -21,7 +17,6 @@ import java.util.stream.Collectors;
 public class ReviewApiService {
 
     private final ReviewRepository reviewRepository;
-    private final PaginationService paginationService;
 
 
     public Page<ReviewDto> getReviewListByPlaceId(String placeId, Pageable pageable) {
@@ -30,23 +25,23 @@ public class ReviewApiService {
         long beforeTime = System.currentTimeMillis();
 
         log.info("[ReviewApiService getReviewList] get review list start...");
-        List<ReviewDto> dtos = reviewRepository.findByKpid(placeId).stream().map(ReviewDto::from).collect(Collectors.toList());
-        log.info("[ReviewApiService getReviewList] get review list complete, size : {}", dtos.size());
+        Page<ReviewDto> dtos = reviewRepository.findByKpid(placeId, pageable).map(review -> ReviewDto.from(review));
+        log.info("[ReviewApiService getReviewList] get review list complete, size : {}", dtos.getSize());
 
         // 인덱스 계산용 시간 측정
         long afterTime = System.currentTimeMillis();
         log.info("elapsed time : " + (afterTime - beforeTime));
 
-        return paginationService.listToPage(dtos, pageable);
+        return dtos;
     }
 
     public Page<ReviewDto> getReviewListByNickname(String nickname, Pageable pageable) {
 
         log.info("[ReviewApiService getReviewList] get review list start...");
-        List<ReviewDto> dtos = reviewRepository.findByUser_Nickname(nickname).stream().map(ReviewDto::from).collect(Collectors.toList());
-        log.info("[ReviewApiService getReviewList] get review list complete, size : {}", dtos.size());
+        Page<ReviewDto> dtos = reviewRepository.findByUser_Nickname(nickname, pageable).map(review -> ReviewDto.from(review));
+        log.info("[ReviewApiService getReviewList] get review list complete, size : {}", dtos.getSize());
 
-        return paginationService.listToPage(dtos, pageable);
+        return dtos;
     }
 
 

--- a/module-api/src/main/java/dev/be/moduleapi/support/controller/AnnouncementApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/support/controller/AnnouncementApiController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -38,7 +39,7 @@ public class AnnouncementApiController {
                                                                      @RequestParam(required = false) Long categoryId,
                                                                      @Parameter(description = "검색 키워드, 기본값 null", required = false)
                                                                      @RequestParam(required = false) String keyword,
-                                                                     @ParameterObject @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+                                                                     @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         return responseService.getPageResult(announcementApiService.getAnnouncementListWithCondition(condition, categoryId, keyword, pageable));
 

--- a/module-api/src/main/java/dev/be/moduleapi/support/controller/QnaApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/support/controller/QnaApiController.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.api.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -115,7 +116,7 @@ public class QnaApiController {
     @GetMapping("/api/v1/questions")
     public PageResult<QuestionDto> getQuestionsByUserNicknameV1(
             @Parameter(description = "요청한 유저의 인증 정보", required = true) Authentication authentication,
-            @ParameterObject @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         User user = (User) authentication.getPrincipal();
         String nickname = user.getNickname();

--- a/module-api/src/main/java/dev/be/moduleapi/support/service/FaqApiService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/support/service/FaqApiService.java
@@ -4,7 +4,6 @@ import dev.be.moduleapi.support.dto.FaqCategoryDto;
 import dev.be.moduleapi.support.dto.FaqDto;
 import dev.be.modulecore.repositories.support.FaqCategoryRepository;
 import dev.be.modulecore.repositories.support.FaqRepository;
-import dev.be.modulecore.service.PaginationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -13,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.stream.Collectors;
 
 @Slf4j(topic = "SERVICE")
 @RequiredArgsConstructor
@@ -23,12 +21,11 @@ public class FaqApiService {
 
     private final FaqRepository faqRepository;
     private final FaqCategoryRepository faqCategoryRepository;
-    private final PaginationService paginationService;
 
 
     public Page<FaqCategoryDto> getFaqCategoryList(Pageable pageable) {
 
-        return paginationService.listToPage(faqCategoryRepository.findAll().stream().map(FaqCategoryDto::from).collect(Collectors.toList()), pageable);
+        return faqCategoryRepository.findAll(pageable).map(favoriteQuestionCategory -> FaqCategoryDto.from(favoriteQuestionCategory));
 
     }
 

--- a/module-api/src/main/java/dev/be/moduleapi/support/service/QnaApiService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/support/service/QnaApiService.java
@@ -2,7 +2,6 @@ package dev.be.moduleapi.support.service;
 
 import dev.be.moduleapi.support.dto.QuestionDto;
 import dev.be.modulecore.repositories.support.QuestionRepository;
-import dev.be.modulecore.service.PaginationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -11,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
-import java.util.stream.Collectors;
 
 @Slf4j(topic = "SERVICE")
 @RequiredArgsConstructor
@@ -20,11 +18,10 @@ import java.util.stream.Collectors;
 public class QnaApiService {
 
     private final QuestionRepository questionRepository;
-    private final PaginationService paginationService;
 
 
     public Page<QuestionDto> getQuestions(String nickname, Pageable pageable) {
-        return paginationService.listToPage(questionRepository.findByUser_Nickname(nickname).stream().map(QuestionDto::from).collect(Collectors.toList()), pageable);
+        return questionRepository.findByUser_Nickname(nickname, pageable).map(question -> QuestionDto.from(question));
     }
 
     public QuestionDto getQuestion(Long id) {

--- a/module-api/src/test/java/dev/be/moduleapi/place/controller/PlaceApiControllerTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/place/controller/PlaceApiControllerTest.java
@@ -62,6 +62,7 @@ class PlaceApiControllerTest {
         testKakaoApiResponseDto.setDocumentList(testDocumentList);
         String address = "서울 관악구";
         String testRegion1 = testDocumentDto.getRegion1DepthName();
+        String sortType = "score";
 
         List<String> testRegion2List = new ArrayList<>();
         String testRegion2 = "관악구";
@@ -73,7 +74,7 @@ class PlaceApiControllerTest {
 
         Pageable pageable = Pageable.ofSize(10);
 
-        given(placeApiService.getPlaces(testDocumentDto, testKakaoApiResponseDto, testRegion2List, testCategoryList, pageable)).willReturn(Page.empty());
+        given(placeApiService.getPlaces(testDocumentDto, testKakaoApiResponseDto, testRegion2List, testCategoryList, pageable, sortType)).willReturn(Page.empty());
         //given(responseService.getPageResult(Page.empty())).willReturn(Page.empty());
 
         // When & Then
@@ -86,7 +87,7 @@ class PlaceApiControllerTest {
                 //.andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 //.andExpect(jsonPath("$.size()").value("0"))
                 .andDo(MockMvcResultHandlers.print());
-        then(placeApiService.getPlaces(testDocumentDto, testKakaoApiResponseDto, testRegion2List, testCategoryList, pageable));
+        then(placeApiService.getPlaces(testDocumentDto, testKakaoApiResponseDto, testRegion2List, testCategoryList, pageable, sortType));
         //then(responseService.getPageResult(Page.empty()));
 
     }

--- a/module-api/src/test/java/dev/be/moduleapi/place/service/PlaceApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/place/service/PlaceApiServiceTest.java
@@ -56,13 +56,14 @@ class PlaceApiServiceTest {
 
         List<String> testCategoryList = new ArrayList<>();
         String testCategory = "CE7";
+        String sortType = "score";
         testCategoryList.add(testCategory);
 
         Pageable pageable = Pageable.ofSize(10);
         given(placeRepository.findByRegion1DepthNameAndRegion2DepthNameAndCategory(testRegion1, testRegion2List, testCategoryList)).willReturn(Collections.emptyList());
 
         // When
-        Page<PlaceDto> result = sut.getPlaces(testDocumentDto, testKakaoApiResponseDto, testRegion2List, testCategoryList, pageable);
+        Page<PlaceDto> result = sut.getPlaces(testDocumentDto, testKakaoApiResponseDto, testRegion2List, testCategoryList, pageable, sortType);
 
         // Then
         assertThat(result).isEmpty();

--- a/module-core/src/main/java/dev/be/modulecore/enums/ErrorCode.java
+++ b/module-core/src/main/java/dev/be/modulecore/enums/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
     USER_ALREADY_EXISTS(6014, "이미 존재하는 회원입니다"),
     VALIDATION_ERROR(6015, "입력된 데이터에 오류가 존재합니다"),
     ANNOUNCEMENT_NOT_FOUND(6016, "공지사항을 찾을 수 없습니다"),
+    SORTTYPE_INVALID(6017, "유효하지 않은 정렬 기준입니다"),
 
     // DB 관련
     DATA_ACCESS_ERROR(7000, "잘못된 요청입니다"), // DataAccessException, 다양한 Data Access 관련 (JDBC, Hibernate, JPA 등) 스프링 예외

--- a/module-core/src/main/java/dev/be/modulecore/repositories/bookmark/BookmarkRepository.java
+++ b/module-core/src/main/java/dev/be/modulecore/repositories/bookmark/BookmarkRepository.java
@@ -1,6 +1,8 @@
 package dev.be.modulecore.repositories.bookmark;
 
 import dev.be.modulecore.domain.bookmark.Bookmark;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,8 +12,12 @@ import java.util.List;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
+    /* 테스트 수정 후 삭제 필요 */
     @EntityGraph(attributePaths = {"user", "place"})
     List<Bookmark> findByUser_Email(String email);
+
+    @EntityGraph(attributePaths = {"user", "place"})
+    Page<Bookmark> findByUser_Email(String email, Pageable pageable);
 
     @EntityGraph(attributePaths = {"user", "place"})
     void deleteById(Long id);

--- a/module-core/src/main/java/dev/be/modulecore/repositories/plan/PlanRepository.java
+++ b/module-core/src/main/java/dev/be/modulecore/repositories/plan/PlanRepository.java
@@ -1,6 +1,8 @@
 package dev.be.modulecore.repositories.plan;
 
 import dev.be.modulecore.domain.plan.Plan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,8 +11,12 @@ import java.util.Optional;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
+    /* 테스트 수정 후 삭제 필요 */
     @EntityGraph(attributePaths = "user")
     List<Plan> findByUser_Nickname(String nickname);
+
+    @EntityGraph(attributePaths = "user")
+    Page<Plan> findByUser_Nickname(String nickname, Pageable pageable);
 
     @Override
     @EntityGraph(attributePaths = "user")

--- a/module-core/src/main/java/dev/be/modulecore/repositories/review/ReviewRepository.java
+++ b/module-core/src/main/java/dev/be/modulecore/repositories/review/ReviewRepository.java
@@ -1,6 +1,8 @@
 package dev.be.modulecore.repositories.review;
 
 import dev.be.modulecore.domain.review.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,11 +11,19 @@ import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
+    /* 테스트 수정 후 삭제 필요*/
     @EntityGraph(attributePaths = {"user", "place", "images"})
     List<Review> findByKpid(String placeId);
 
     @EntityGraph(attributePaths = {"user", "place", "images"})
+    Page<Review> findByKpid(String placeId, Pageable pageable);
+
+    /* 테스트 수정 후 삭제 필요*/
+    @EntityGraph(attributePaths = {"user", "place", "images"})
     List<Review> findByUser_Nickname(String nickname);
+
+    @EntityGraph(attributePaths = {"user", "place", "images"})
+    Page<Review> findByUser_Nickname(String nickname, Pageable pageable);
 
     @Override
     @EntityGraph(attributePaths = {"user", "place", "images"})

--- a/module-core/src/main/java/dev/be/modulecore/repositories/support/AnnouncementAdminRepository.java
+++ b/module-core/src/main/java/dev/be/modulecore/repositories/support/AnnouncementAdminRepository.java
@@ -1,6 +1,8 @@
 package dev.be.modulecore.repositories.support;
 
 import dev.be.modulecore.domain.support.Announcement;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,7 +13,7 @@ public interface AnnouncementAdminRepository extends JpaRepository<Announcement,
 
     @EntityGraph(attributePaths = "announcementCategory")
     @Override
-    List<Announcement> findAll();
+    Page<Announcement> findAll(Pageable pageable);
 
     @EntityGraph(attributePaths = "announcementCategory")
     @Override

--- a/module-core/src/main/java/dev/be/modulecore/repositories/support/FaqCategoryRepository.java
+++ b/module-core/src/main/java/dev/be/modulecore/repositories/support/FaqCategoryRepository.java
@@ -1,6 +1,8 @@
 package dev.be.modulecore.repositories.support;
 
 import dev.be.modulecore.domain.support.FavoriteQuestionCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,7 +13,7 @@ public interface FaqCategoryRepository extends JpaRepository<FavoriteQuestionCat
 
     @EntityGraph(attributePaths = "favoriteAnswers")
     @Override
-    List<FavoriteQuestionCategory> findAll();
+    Page<FavoriteQuestionCategory> findAll(Pageable pageable);
 
     @EntityGraph(attributePaths = "favoriteAnswers")
     @Override

--- a/module-core/src/main/java/dev/be/modulecore/repositories/support/QuestionAdminRepository.java
+++ b/module-core/src/main/java/dev/be/modulecore/repositories/support/QuestionAdminRepository.java
@@ -1,6 +1,8 @@
 package dev.be.modulecore.repositories.support;
 
 import dev.be.modulecore.domain.support.Question;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,7 +17,7 @@ public interface QuestionAdminRepository extends JpaRepository<Question, Long> {
 
     @Override
     @EntityGraph(attributePaths = {"user", "questionCategory"})
-    List<Question> findAll();
+    Page<Question> findAll(Pageable pageable);
 
     void deleteById(Long id);
 

--- a/module-core/src/main/java/dev/be/modulecore/repositories/support/QuestionRepository.java
+++ b/module-core/src/main/java/dev/be/modulecore/repositories/support/QuestionRepository.java
@@ -1,6 +1,8 @@
 package dev.be.modulecore.repositories.support;
 
 import dev.be.modulecore.domain.support.Question;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -18,7 +20,7 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findAll();
 
     @EntityGraph(attributePaths = {"user", "questionCategory"})
-    List<Question> findByUser_Nickname(String nickname);
+    Page<Question> findByUser_Nickname(String nickname, Pageable pageable);
 
     void deleteById(Long id);
 


### PR DESCRIPTION
현재 API쪽 페이징 기능이 제대로 작동하지 않고 있어 수정이 필요하다
또한 QueryDsl을 활용한 조회 메서드에 동적 정렬 기능을 추가해야 한다

* [x] Page 객체를 바로 반활할 수 있는 도메인 - 페이징 정렬 기능 수정
  * [x] 북마크
  * [x] 리뷰
  * [x] 플랜
  * [x] 공지사항 (어드민)
  * [x] Q&A (API, 어드민)
* [x] QueryDsl 활용 조회 메서드에 동적 정렬 기능 추가
  * [x] 장소
  * [x] 사용자 (어드민)

This closes #106 