### PR TITLE
[BE] API 통합 테스트 일부 -> 단위 테스트 전환

### DIFF
--- a/module-api/src/main/java/dev/be/moduleapi/config/SecurityConfig.java
+++ b/module-api/src/main/java/dev/be/moduleapi/config/SecurityConfig.java
@@ -109,8 +109,9 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(Arrays.asList("*"));
-        configuration.setAllowedMethods(Arrays.asList("HEAD", "GET", "POST", "PUT", "DELETE")); // 허용할 메서드
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Cache-Control", "Content-Type")); // 허용할 Http 헤더
+        configuration.addAllowedOrigin("http://localhost:5173");
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
 

--- a/module-api/src/test/java/dev/be/moduleapi/bookmark/BookmarkApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/bookmark/BookmarkApiServiceTest.java
@@ -6,28 +6,24 @@ import dev.be.modulecore.repositories.bookmark.BookmarkRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("[통합] 북마크 화면 처리 서비스 - 북마크 조회 테스트")
+@DisplayName("[단일] 북마크 화면 처리 서비스 - 북마크 조회 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
 class BookmarkApiServiceTest {
 
-    @Autowired
+    @InjectMocks
     private BookmarkApiService sut;
 
-    @MockBean
+    @Mock
     private BookmarkRepository bookmarkRepository;
 
 

--- a/module-api/src/test/java/dev/be/moduleapi/plan/service/DetailPlanApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/plan/service/DetailPlanApiServiceTest.java
@@ -9,10 +9,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.access.AccessDeniedException;
 
 import java.util.Optional;
@@ -22,15 +21,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("[통합] 플랜 화면 처리 서비스 - 세부 플랜 조회 테스트")
+@DisplayName("[단일] 플랜 화면 처리 서비스 - 세부 플랜 조회 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
 class DetailPlanApiServiceTest {
 
-    @Autowired
+    @InjectMocks
     private DetailPlanApiService sut;
 
-    @MockBean
+    @Mock
     private DetailPlanRepository detailPlanRepository;
 
 

--- a/module-api/src/test/java/dev/be/moduleapi/plan/service/PlanApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/plan/service/PlanApiServiceTest.java
@@ -9,30 +9,27 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 
-import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("[통합] 플랜 화면 처리 서비스 - 플랜 조회 테스트")
+@DisplayName("[단일] 플랜 화면 처리 서비스 - 플랜 조회 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
 class PlanApiServiceTest {
 
-    @Autowired
+    @InjectMocks
     private PlanApiService sut;
 
-    @MockBean
+    @Mock
     private PlanRepository planRepository;
 
 
@@ -86,7 +83,7 @@ class PlanApiServiceTest {
 
         // When & Then
         Assertions.assertThrows(PlanNotFoundApiException.class, () -> {
-           sut.getPlan(id, nickname);
+            sut.getPlan(id, nickname);
         });
         then(planRepository).should().findById(id);
 
@@ -104,7 +101,7 @@ class PlanApiServiceTest {
 
         // When & Then
         Assertions.assertThrows(AccessDeniedException.class, () -> {
-           sut.getPlan(id, nickname);
+            sut.getPlan(id, nickname);
         });
         then(planRepository).should().findById(id);
 

--- a/module-api/src/test/java/dev/be/moduleapi/review/service/ReviewApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/review/service/ReviewApiServiceTest.java
@@ -9,29 +9,26 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("[통합] 리뷰 화면 처리 서비스 - 리뷰 조회 테스트")
+@DisplayName("[단일] 리뷰 화면 처리 서비스 - 리뷰 조회 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
 class ReviewApiServiceTest {
 
-    @Autowired
+    @InjectMocks
     private ReviewApiService sut;
 
-    @MockBean
+    @Mock
     private ReviewRepository reviewRepository;
 
     @DisplayName("READ - 장소 내 리뷰 리스트 조회")

--- a/module-api/src/test/java/dev/be/moduleapi/support/service/FaqApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/support/service/FaqApiServiceTest.java
@@ -7,14 +7,12 @@ import dev.be.modulecore.domain.support.FavoriteAnswer;
 import dev.be.modulecore.domain.support.FavoriteQuestionCategory;
 import dev.be.modulecore.repositories.support.FaqCategoryRepository;
 import dev.be.modulecore.repositories.support.FaqRepository;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -26,18 +24,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("[통합] FAQ 화면 처리 서비스 - FAQ 조회 테스트")
+@DisplayName("[단일] FAQ 화면 처리 서비스 - FAQ 조회 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
 class FaqApiServiceTest {
 
-    @Autowired
+    @InjectMocks
     private FaqApiService sut;
 
-    @MockBean
+    @Mock
     private FaqRepository faqRepository;
 
-    @MockBean
+    @Mock
     private FaqCategoryRepository faqCategoryRepository;
 
     @DisplayName("READ - FAQ 리스트 조회")
@@ -87,7 +84,7 @@ class FaqApiServiceTest {
 
         // When & Then
         assertThrows(EntityNotFoundException.class, () -> {
-           sut.getFaqCategory(id);
+            sut.getFaqCategory(id);
         });
         then(faqCategoryRepository).should().findById(id);
 
@@ -123,7 +120,7 @@ class FaqApiServiceTest {
 
         // When & Then
         assertThrows(EntityNotFoundException.class, () -> {
-           sut.getFaq(id);
+            sut.getFaq(id);
         });
         then(faqRepository).should().findById(id);
 

--- a/module-api/src/test/java/dev/be/moduleapi/support/service/QnaApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/support/service/QnaApiServiceTest.java
@@ -7,10 +7,9 @@ import dev.be.modulecore.repositories.support.QuestionRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -22,15 +21,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
-@DisplayName("[통합] QNA 화면 처리 서비스 - QNA 조회 테스트")
+@DisplayName("[단일] QNA 화면 처리 서비스 - QNA 조회 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
 class QnaApiServiceTest {
 
-    @Autowired
+    @InjectMocks
     private QnaApiService sut;
 
-    @MockBean
+    @Mock
     private QuestionRepository questionRepository;
 
     @DisplayName("READ - QNA 리스트 조회")
@@ -81,7 +79,7 @@ class QnaApiServiceTest {
 
         // When & Then
         assertThrows(EntityNotFoundException.class, () -> {
-           sut.getQuestion(id);
+            sut.getQuestion(id);
         });
         then(questionRepository).should().findById(id);
 


### PR DESCRIPTION
화면 처리에 대한 테스트를 굳이 통합 테스트로 할 필요가 없을 것 같아 단위 테스트로 전환한다
앞서 설명한 대로 API에 대한 통합 테스트는 Swagger-UI에서의 테스트로 대체한다

This closes #119 