### PR TITLE
[BE] JWT 인증 방식 리팩토링

### DIFF
--- a/module-api/src/main/java/dev/be/moduleapi/bookmark/controller/BookmarkApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/bookmark/controller/BookmarkApiController.java
@@ -10,8 +10,6 @@ import dev.be.moduleapi.bookmark.service.BookmarkService;
 import dev.be.modulecore.domain.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,13 +33,6 @@ public class BookmarkApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[POST] 북마크 목록에 저장, 사용자 로그인 되어 있어야 함",
             description = "지정한 장소를 북마크 목록에 저장합니다. 저장하려는 장소의 place_id를 가져와서 다음과 같이 요청해야 합니다. <br>" +
                     "[POST] /api/v1/bookmarks?placeId={place_id} <br><br>" +
@@ -60,13 +51,6 @@ public class BookmarkApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 북마크 목록 출력, 사용자 로그인 되어 있어야 함",
             description = "요청 시점에서 요청을 한 유저의 인증 정보를 확인하여 해당 유저가 저장해둔 북마크 리스트를 출력합니다. <br>" +
                     "이들 장소에 대한 상세 정보는 장소 단건 조회 API /api/v1/places/{place_id} 를 활용합니다.")
@@ -83,13 +67,6 @@ public class BookmarkApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[DELETE] 북마크 삭제, 사용자 로그인 되어 있어야 함",
             description = "지정한 북마크를 삭제합니다. 삭제하려는 북마크의 id를 가져와서 다음과 같이 요청해야 합니다. <br>" +
                     "[DELETE] /api/v1/bookmarks/{id} <br><br>" +

--- a/module-api/src/main/java/dev/be/moduleapi/config/OpenApiConfig.java
+++ b/module-api/src/main/java/dev/be/moduleapi/config/OpenApiConfig.java
@@ -1,7 +1,10 @@
 package dev.be.moduleapi.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,6 +13,18 @@ public class OpenApiConfig {
 
     @Bean
     public OpenAPI config() {
+
+        String jwtSchemeName = "jwtAuth";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("Authorization"));
+
         return new OpenAPI()
                 .info(new Info().title("Date-planner API 서버")
                         .description("API 명세서와 테스트를 위한 API를 제공하고 있습니다")
@@ -17,7 +32,9 @@ public class OpenApiConfig {
                         .contact(new io.swagger.v3.oas.models.info.Contact()
                                 .name("더블코코볼 mrcocoball")
                                 .email("gunmaru93@gmai.com")
-                                .url("https://github.com/mrcocoball/date-planner")));
+                                .url("https://github.com/mrcocoball/date-planner")))
+                .addSecurityItem(securityRequirement)
+                .components(components);
     }
 
 

--- a/module-api/src/main/java/dev/be/moduleapi/place/controller/PlaceApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/place/controller/PlaceApiController.java
@@ -14,8 +14,6 @@ import dev.be.moduleapi.place.service.PlaceService;
 import dev.be.modulecore.domain.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -76,14 +74,6 @@ public class PlaceApiController {
         return responseService.getPageResult(placeApiService.getPlaces(addressDto, dto, region2List, categories, pageable, sortType));
     }
 
-    
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = false, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 장소 ID로 단일 장소 정보 조회",
             description = "장소 ID (place_id)를 통해 특정 장소의 정보를 가져옵니다. <br><br>" +
                     "사용하는 데이터 : 전부 사용하며 해당 API 및 데이터는 세부 플랜 장소 검색 시에도 활용합니다.")

--- a/module-api/src/main/java/dev/be/moduleapi/plan/controller/DetailPlanApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/plan/controller/DetailPlanApiController.java
@@ -10,8 +10,6 @@ import dev.be.moduleapi.plan.service.DetailPlanService;
 import dev.be.modulecore.domain.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,13 +34,6 @@ public class DetailPlanApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[POST] 세부 플랜(목적지) 설정 요청, 사용자 로그인이 되어야 함",
             description = "특정 플랜 내부에 세부 플랜(목적지) 설정을 요청합니다. 이 때 특정 플랜의 ID (pid)를 사용해야 하며, 다음과 같이 요청해야 합니다. <br>" +
                     "[POST] /api/v1/detailPlans?planId={pid} <br><br>" +
@@ -65,13 +56,6 @@ public class DetailPlanApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 세부 플랜(목적지) ID로 단건 조회, 사용자 로그인이 되어야 하며 플랜 ID 필요, 플랜 작성자일 경우에만 조회 가능",
             description = "세부 플랜(목적지) ID (id)를 통해 특정 세부 플랜의 정보를 가져옵니다. <br>" +
                     "또한 요청 시점에서 요청을 한 유저의 인증 정보를 확인하여 접근 권한을 체크합니다. <br><br>" +
@@ -88,13 +72,6 @@ public class DetailPlanApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[PUT] 세부 플랜(목적지) 수정, 사용자 로그인이 되어야 하며 세부 플랜 ID 필요",
             description = "세부 플랜(목적지) ID (id)를 통해 특정 세부 플랜의 정보를 수정합니다. <br><br>" +
                     "해당 기능을 사용하기 전에 위의 [GET] /api/v1/detailPlans/{id} 로 수정 전 정보를 가져와야 합니다. 이후 수정 완료 버튼 클릭 시 다음과 같이 요청해야 합니다. <br>" +
@@ -114,13 +91,6 @@ public class DetailPlanApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[DELETE] 세부 플랜(목적지) 삭제, 사용자 로그인이 되어야 하며 세부 플랜 ID 필요",
             description = "지정한 세부 플랜(목적지)를 삭제합니다. 삭제하려는 세부 플랜의 id를 가져와서 다음과 같이 요청해야 합니다. <br>" +
                     "[DELETE] /api/v1/detailPlans/{id} <br><br>" +

--- a/module-api/src/main/java/dev/be/moduleapi/plan/controller/PlanApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/plan/controller/PlanApiController.java
@@ -11,8 +11,6 @@ import dev.be.moduleapi.plan.service.PlanService;
 import dev.be.modulecore.domain.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,13 +38,6 @@ public class PlanApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[POST] 플랜 작성 요청, 사용자 로그인이 되어야 함",
             description = "플랜 작성을 요청합니다. 이 때 요청 시점에서 요청을 한 유저의 인증 정보를 확인하며, <br>" +
                     "해당 인증 정보를 토대로 플랜을 작성하려는 유저를 체크합니다. <br><br>" +
@@ -64,13 +55,6 @@ public class PlanApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 사용자 작성 플랜 리스트 출력, 사용자 로그인이 되어야 함",
             description = "마이페이지 내 내 플랜 화면에서 사용자가 작성한 플랜 리스트를 출력합니다. <br>" +
                     "요청 시점에서 요청을 한 유저의 인증 정보를 확인하여 해당 유저가 작성한 플랜 리스트를 출력합니다.")
@@ -88,13 +72,6 @@ public class PlanApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 플랜 ID로 플랜 단건 조회, 사용자 로그인이 되어야 함",
             description = "플랜 ID (id)를 통해 특정 플랜의 정보와, 플랜 내의 세부 플랜(목적지) 리스트를 가져옵니다. <br><br>" +
                     "사용하는 데이터 : 전부 사용하며 플랜 수정 시 필요한 uid (작성자 ID), id (플랜 ID) 를 비롯한 수정 전 기존 정보를 해당 API로 가져옵니다.")
@@ -110,13 +87,6 @@ public class PlanApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[PUT] 플랜 수정, 사용자 로그인이 되어야 하며 플랜 ID 필요",
             description = "플랜 ID (id)를 통해 특정 플랜의 정보를 수정합니다. <br>" +
                     "해당 기능을 사용하기 전에 위의 [GET] /api/v1/plans/{id} 로 수정 전 정보를 가져와야 합니다. 이후 수정 완료 버튼 클릭 시 다음과 같이 요청해야 합니다. <br>" +
@@ -143,13 +113,6 @@ public class PlanApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[DELETE] 플랜 삭제, 사용자 로그인이 되어야 하며 플랜 ID 필요",
             description = "지정한 플랜을 삭제합니다. 삭제하려는 플랜의 id를 가져와서 다음과 같이 요청해야 합니다. <br>" +
                     "[DELETE] /api/v1/plans/{id} <br><br>" +
@@ -164,13 +127,6 @@ public class PlanApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[PUT] 플랜 완료 처리, 사용자 로그인이 되어야 하며 플랜 ID 필요",
             description = "지정한 플랜을 완료 처리합니다. 완료 처리하려는 플랜의 id를 가져와서 다음과 같이 요청해야 합니다. <br>" +
                     "[PUT] /api/v1/plans/{id}/finish <br><br>" +

--- a/module-api/src/main/java/dev/be/moduleapi/review/controller/ReviewApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/review/controller/ReviewApiController.java
@@ -12,8 +12,6 @@ import dev.be.moduleapi.review.service.ReviewService;
 import dev.be.modulecore.domain.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,13 +41,6 @@ public class ReviewApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[POST] 리뷰 작성 요청, 사용자 로그인 되어 있어야 함",
             description = "특정 장소에 리뷰 작성을 요청합니다. 이 때 특정 장소의 place_id를 사용해야 합니다. <br>" +
                     "또한 요청 시점에서 요청을 한 유저의 인증 정보를 확인하며, 해당 인증 정보를 토대로 리뷰를 작성하려는 유저를 체크합니다. <br><br>" +
@@ -70,13 +61,6 @@ public class ReviewApiController {
         return responseService.getSingleResult(reviewService.saveReview(dto));
     }
 
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 장소 내의 리뷰 리스트 출력",
             description = "특정 장소에 작성된 리뷰 리스트를 출력합니다. 장소 상세 정보 조회 시 해당 API도 같이 호출되어야 합니다. <br>" +
                     "특정 장소의 장소 ID (place_id) 가 필요합니다.")
@@ -89,13 +73,6 @@ public class ReviewApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 사용자 작성 리뷰 리스트 출력, 로그인 되어 있어야 함",
             description = "마이페이지 내 내 리뷰 화면에서 사용자가 작성한 리뷰 리스트를 출력합니다. <br>" +
                     "요청 시점에서 요청을 한 유저의 인증 정보를 확인하여 해당 유저가 작성한 리뷰 리스트를 출력합니다. <br><br>" +
@@ -113,13 +90,6 @@ public class ReviewApiController {
         return responseService.getPageResult(reviewApiService.getReviewListByNickname(nickname, pageable));
     }
 
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 리뷰 ID로 단일 리뷰 조회",
             description = "리뷰 ID (id)를 통해 특정 리뷰의 정보를 가져옵니다. <br><br>" +
                     "사용하는 데이터 : 전부 사용하며 리뷰 수정 시 필요한 uid (작성자 ID), pid (장소 ID, PK) 를 비롯한 수정 전 기존 정보를 해당 API로 가져옵니다.")
@@ -131,13 +101,6 @@ public class ReviewApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[PUT] 리뷰 수정, 사용자 로그인 되어 있어야 함",
             description = "리뷰 ID (id)를 통해 특정 리뷰의 정보를 수정합니다. <br><br>" +
                     "해당 기능을 사용하기 전에 위의 [GET] /api/v1/reviews/{id} 로 수정 전 정보를 가져와야 합니다. 이후 수정 완료 버튼 클릭 시 다음과 같이 요청해야 합니다. <br>" +
@@ -162,13 +125,6 @@ public class ReviewApiController {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[DELETE] 리뷰 삭제, 사용자 로그인 되어 있어야 함",
             description = "지정한 리뷰를 삭제합니다. 삭제하려는 리뷰의 id를 가져와서 다음과 같이 요청해야 합니다. <br>" +
                     "[DELETE] /api/v1/reviews/{id} <br><br>" +

--- a/module-api/src/main/java/dev/be/moduleapi/security/dto/AccessTokenDto.java
+++ b/module-api/src/main/java/dev/be/moduleapi/security/dto/AccessTokenDto.java
@@ -11,7 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TokenDto {
+public class AccessTokenDto {
 
     @Schema(description = "토큰 타입, Bearer 사용")
     private String grantType;
@@ -20,11 +20,6 @@ public class TokenDto {
     @JsonProperty("Authorization")
     private String accessToken;
 
-    @Schema(description = "리프레시 토큰")
-    @JsonProperty("refresh_token")
-    private String refreshToken;
-
     @Schema(description = "액세스 토큰 만료일")
     private Long accessTokenExpireDate;
-
 }

--- a/module-api/src/main/java/dev/be/moduleapi/support/controller/QnaApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/support/controller/QnaApiController.java
@@ -12,8 +12,6 @@ import dev.be.moduleapi.support.service.QnaService;
 import dev.be.modulecore.domain.user.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,13 +40,6 @@ public class QnaApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[POST] 문의 작성 요청, 사용자 로그인 되어 있어야 함",
             description = "문의 작성을 요청합니다. <br>" +
                     "요청 시점에서 요청을 한 유저의 인증 정보를 확인하며, 해당 인증 정보를 토대로 문의를 작성하려는 유저를 체크합니다. <br><br>" +
@@ -71,13 +62,6 @@ public class QnaApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[PUT] 문의 수정, 사용자 로그인 되어 있어야 함",
             description = "문의 ID (id)를 통해 특정 문의의 정보를 수정합니다. <br><br>" +
                     "해당 기능을 사용하기 전에 위의 [GET] /api/v1/questions/{id} 로 수정 전 정보를 가져와야 합니다. 이후 수정 완료 버튼 클릭 시 다음과 같이 요청해야 합니다. <br>" +
@@ -103,13 +87,6 @@ public class QnaApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 사용자 작성 문의 리스트 출력, 로그인 되어 있어야 함",
             description = "사용자가 작성한 문의 리스트를 출력합니다. <br>" +
                     "요청 시점에서 요청을 한 유저의 인증 정보를 확인하여 해당 유저가 작성한 문의 리스트를 출력합니다.")
@@ -126,13 +103,6 @@ public class QnaApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[GET] 문의 ID로 단일 문의 내용 조회",
             description = "문의 ID (id)를 통해 특정 문의의 정보를 가져옵니다. <br><br>" +
                     "사용하는 데이터 : 전부 사용하며 문의 수정 시 필요한 uid (작성자 ID), nickname (작성자 닉네임) 을 비롯한 수정 전 기존 정보를 해당 API로 가져옵니다.")
@@ -145,13 +115,6 @@ public class QnaApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[DELETE] 문의 삭제, 사용자 로그인 되어 있어야 함",
             description = "지정한 문의를 삭제합니다. 삭제하려는 문의의 id를 가져와서 다음과 같이 요청해야 합니다. <br>" +
                     "[DELETE] /api/v1/questions/{id} <br><br>" +
@@ -167,13 +130,6 @@ public class QnaApiController {
 
 
     @PreAuthorize("isAuthenticated()")
-    @Parameters({
-            @Parameter(
-                    name = "X-AUTH-TOKEN",
-                    description = "로그인 성공 후 AccessToken",
-                    required = true, in = ParameterIn.HEADER
-            )
-    })
     @Operation(summary = "[POST] 문의 내 답변 작성 요청, 사용자 로그인 되어 있어야 함",
             description = "문의 내 답변 작성을 요청합니다. <br>" +
                     "요청 시점에서 요청을 한 유저의 인증 정보를 확인하며, 해당 인증 정보를 토대로 문의를 작성하려는 유저를 체크합니다. <br><br>" +


### PR DESCRIPTION
JWT 인증 방식을 다시 갈아 엎어야 할 것으로 보인다
로그인 시 액세스 토큰은 JSON으로, 리프레시 토큰은 HttpOnly 로 전달되게 하고
프론트엔드에서 이를 활용해 인증을 요청할 수 있도록 로직을 바꾼다.
추가적으로, Swagger-UI에서 X-AUTH-TOKEN 헤더를 이용한 인증이 아닌 Authorization 헤더를 통한 인증을 하도록 변경한다.

* [x] 리팩토링
* [x] 프론트엔드 서버 테스트
* [x] Swagger-UI 설정 변경

This closes #121 