### PR TITLE
[BE] API 서버 인증, 생성 / 수정 기능 응답 스펙 수정

### DIFF
--- a/module-api/src/main/java/dev/be/moduleapi/bookmark/controller/BookmarkApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/bookmark/controller/BookmarkApiController.java
@@ -40,7 +40,7 @@ public class BookmarkApiController {
                     "[POST] /api/v1/bookmarks?placeId={place_id} <br><br>" +
                     "요청 시점에서 요청을 한 유저의 인증 정보를 확인하며, 해당 인증 정보를 토대로 북마크를 저장하려는 유저를 체크합니다.")
     @PostMapping("/api/v1/bookmarks")
-    public SingleResult<Long> saveBookmarkV1(
+    public SingleResult<BookmarkDto> saveBookmarkV1(
             @Parameter(description = "요청한 유저의 인증 정보", required = true) Authentication authentication,
             @Parameter(description = "장소 정보의 place_id (String)", required = true) @RequestParam String placeId) {
 

--- a/module-api/src/main/java/dev/be/moduleapi/bookmark/service/BookmarkService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/bookmark/service/BookmarkService.java
@@ -3,6 +3,7 @@ package dev.be.moduleapi.bookmark.service;
 import dev.be.moduleapi.advice.exception.BookmarkDuplicateException;
 import dev.be.moduleapi.advice.exception.PlaceNotFoundApiException;
 import dev.be.moduleapi.advice.exception.UserNotFoundApiException;
+import dev.be.moduleapi.bookmark.dto.BookmarkDto;
 import dev.be.modulecore.domain.bookmark.Bookmark;
 import dev.be.modulecore.domain.place.Place;
 import dev.be.modulecore.domain.user.User;
@@ -24,7 +25,7 @@ public class BookmarkService {
     private final UserRepository userRepository;
     private final PlaceRepository placeRepository;
 
-    public Long saveBookmark(String nickname, String placeId) {
+    public BookmarkDto saveBookmark(String nickname, String placeId) {
 
         // 중복 체크
         log.info("[BookmarkService saveBookmark] bookmark duplication checking");
@@ -39,7 +40,7 @@ public class BookmarkService {
         Bookmark bookmark = Bookmark.of(user, place, placeId);
         bookmarkRepository.save(bookmark);
 
-        return bookmark.getId();
+        return BookmarkDto.from(bookmark);
     }
 
     public void deleteBookmark(Long id) {

--- a/module-api/src/main/java/dev/be/moduleapi/plan/controller/DetailPlanApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/plan/controller/DetailPlanApiController.java
@@ -44,7 +44,7 @@ public class DetailPlanApiController {
                     "1. 사용자가 장소 검색 기능을 활용하여 최종적으로 선택한 장소에서 place_id를 가져오기<br>" +
                     "2. 사용자가 북마크에 저장된 장소들을 확인하여 최종적으로 선택한 장소에서 place_id를 가져오기")
     @PostMapping(value = "/api/v1/detailPlans", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> saveDetailPlansV1(
+    public SingleResult<DetailPlanDto> saveDetailPlansV1(
             @Parameter(description = "플랜 ID, 세부 플랜(목적지)를 설정하려는 플랜의 플랜 ID(pid)는 프론트엔드에서 가져와서 요청 시 넣어줘야 합니다.",
                     required = true) @RequestParam Long planId,
             @Parameter(description = "세부 플랜 작성 정보, 목적지 장소의 place_id는 위에서 설명한 방식으로 프론트엔드에서 가져와서 요청 시 넣어줘야 합니다.",
@@ -80,7 +80,7 @@ public class DetailPlanApiController {
                     "[PUT] /api/v1/detailPlans/{id} <br><br>" +
                     "수정되는 정보는 place_id, ord 입니다.")
     @PutMapping(value = "/api/v1/detailPlans/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> updateDetailPlanV1(
+    public SingleResult<DetailPlanDto> updateDetailPlanV1(
             @Parameter(description = "세부 플랜(목적지) ID", required = true) @PathVariable("id") Long id,
             @Parameter(description = "세부 플랜(목적지) 수정 정보, 수정 버튼 클릭 시 [GET] /api/v1/detailPlans{id}로 수정 전 정보를 가져와야 합니다.",
                     required = true,

--- a/module-api/src/main/java/dev/be/moduleapi/plan/controller/PlanApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/plan/controller/PlanApiController.java
@@ -45,7 +45,7 @@ public class PlanApiController {
                     "해당 인증 정보를 토대로 플랜을 작성하려는 유저를 체크합니다. <br><br>" +
                     "플랜 작성에 필요한 정보는 제목(title) 입니다.")
     @PostMapping(value = "/api/v1/plans", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> savePlansV1(
+    public SingleResult<PlanDto> savePlansV1(
             @Parameter(description = "요청한 유저의 인증 정보", required = true) Authentication authentication,
             @Parameter(description = "플랜 작성 정보", required = true) @Valid @RequestBody PlanRequestDto dto) {
 
@@ -98,7 +98,7 @@ public class PlanApiController {
                     "(예시 : 플랜 정보 조회로 세부 플랜(id = 1, id = 2) 2개가 같이 나오고, 이 중에서 id = 1인 세부 플랜 클릭 시 [GET] api/v1/detailPlans/{1}...<br>" +
                     "또한 요청 시점에서 요청을 한 유저의 인증 정보를 확인하며, 해당 인증 정보를 토대로 플랜을 수정하려는 유저를 체크합니다.")
     @PutMapping(value = "/api/v1/plans/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> updatePlanV1(
+    public SingleResult<PlanDto> updatePlanV1(
             @Parameter(description = "요청한 유저의 인증 정보", required = true) Authentication authentication,
             @Parameter(description = "플랜 ID", required = true) @PathVariable("id") Long id,
             @Parameter(description = "플랜 수정 정보, 수정 버튼 클릭 시 [GET] /api/v1/plans/{id}로 수정 전 정보를 가져와야 합니다.",

--- a/module-api/src/main/java/dev/be/moduleapi/plan/service/DetailPlanService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/plan/service/DetailPlanService.java
@@ -3,6 +3,7 @@ package dev.be.moduleapi.plan.service;
 import dev.be.moduleapi.advice.exception.DetailPlanNotFoundApiException;
 import dev.be.moduleapi.advice.exception.PlaceNotFoundApiException;
 import dev.be.moduleapi.advice.exception.PlanNotFoundApiException;
+import dev.be.moduleapi.plan.dto.DetailPlanDto;
 import dev.be.moduleapi.plan.dto.DetailPlanRequestDto;
 import dev.be.modulecore.domain.place.Place;
 import dev.be.modulecore.domain.plan.DetailPlan;
@@ -26,7 +27,7 @@ public class DetailPlanService {
     private final PlaceRepository placeRepository;
 
 
-    public Long saveDetailPlan(DetailPlanRequestDto dto) {
+    public DetailPlanDto saveDetailPlan(DetailPlanRequestDto dto) {
 
         log.info("[DetailPlanService saveDetailPlan] find plan...");
 
@@ -43,10 +44,10 @@ public class DetailPlanService {
 
         log.info("[DetailPlanService saveDetailPlan] save detail plan complete");
 
-        return detailPlan.getId();
+        return DetailPlanDto.from(detailPlan);
     }
 
-    public Long updateDetailPlan(DetailPlanRequestDto dto) {
+    public DetailPlanDto updateDetailPlan(DetailPlanRequestDto dto) {
 
         DetailPlan detailPlan = detailPlanRepository.findById(dto.getId()).orElseThrow(DetailPlanNotFoundApiException::new);
 
@@ -61,7 +62,7 @@ public class DetailPlanService {
             detailPlan.changeOrd(dto.getOrd());
         }
 
-        return detailPlan.getId();
+        return DetailPlanDto.from(detailPlan);
     }
 
     public void deleteDetailPlan(Long id) {

--- a/module-api/src/main/java/dev/be/moduleapi/plan/service/PlanService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/plan/service/PlanService.java
@@ -2,6 +2,7 @@ package dev.be.moduleapi.plan.service;
 
 import dev.be.moduleapi.advice.exception.PlanNotFoundApiException;
 import dev.be.moduleapi.advice.exception.UserNotFoundApiException;
+import dev.be.moduleapi.plan.dto.PlanDto;
 import dev.be.moduleapi.plan.dto.PlanRequestDto;
 import dev.be.modulecore.domain.plan.Plan;
 import dev.be.modulecore.domain.user.User;
@@ -22,7 +23,7 @@ public class PlanService {
     private final UserRepository userRepository;
 
 
-    public Long savePlan(PlanRequestDto dto) {
+    public PlanDto savePlan(PlanRequestDto dto) {
 
         User user = userRepository.findByNickname(dto.getNickname()).orElseThrow(UserNotFoundApiException::new);
 
@@ -32,17 +33,17 @@ public class PlanService {
 
         log.info("[PlanService savePlan] save plan complete");
 
-        return plan.getId();
+        return PlanDto.from(plan);
     }
 
-    public Long updatePlan(PlanRequestDto dto) {
+    public PlanDto updatePlan(PlanRequestDto dto) {
 
         Plan plan = planRepository.findById(dto.getId()).orElseThrow(PlanNotFoundApiException::new);
 
         plan.changeTitle(dto.getTitle());
         plan.changeComment(dto.getComment());
 
-        return plan.getId();
+        return PlanDto.from(plan);
     }
 
     public void deletePlan(Long id) {

--- a/module-api/src/main/java/dev/be/moduleapi/review/controller/ReviewApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/review/controller/ReviewApiController.java
@@ -49,7 +49,7 @@ public class ReviewApiController {
                     "리뷰 작성에 필요한 정보는 place_id, title, description, review_score, List <String> filenames 입니다. <br>" +
                     "여기서 List<String>filenames의 경우 첨부 이미지의 주소이며, 여기에는 이미지 업로드 API를 통해 변환된 것을 넣어야 합니다.")
     @PostMapping(value = "/api/v1/reviews", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> saveReviewV1(
+    public SingleResult<ReviewDto> saveReviewV1(
             @Parameter(description = "요청한 유저의 인증 정보") Authentication authentication,
             @Parameter(description = "리뷰 작성 정보, 리뷰를 작성하려는 장소의 장소 ID(place_id)는 프론트엔드에서 가져와서 요청 시 넣어줘야 합니다.",
                     required = true,
@@ -110,7 +110,7 @@ public class ReviewApiController {
                     "수정되는 정보는 title, description, review_score, List<String>filenames 입니다. <br>" +
                     "또한 요청 시점에서 요청을 한 유저의 인증 정보를 확인하며, 해당 인증 정보를 토대로 리뷰를 수정하려는 유저를 체크합니다.")
     @PutMapping(value = "/api/v1/reviews/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> updateReviewV1(
+    public SingleResult<ReviewDto> updateReviewV1(
             @Parameter(description = "사용자 정보", required = true) Authentication authentication,
             @Parameter(description = "리뷰 ID, 리뷰 리스트 내 리뷰의 id를 사용합니다", required = true) @PathVariable("id") Long id,
             @Parameter(description = "리뷰 수정 정보, 수정 버튼 클릭 시 [GET] /api/v1/reviews/{id}로 수정 전 정보를 가져와야 합니다.",

--- a/module-api/src/main/java/dev/be/moduleapi/review/service/ReviewService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package dev.be.moduleapi.review.service;
 import dev.be.moduleapi.advice.exception.PlaceNotFoundApiException;
 import dev.be.moduleapi.advice.exception.ReviewNotFoundApiException;
 import dev.be.moduleapi.advice.exception.UserNotFoundApiException;
+import dev.be.moduleapi.review.dto.ReviewDto;
 import dev.be.moduleapi.review.dto.ReviewRequestDto;
 import dev.be.modulecore.domain.place.Place;
 import dev.be.modulecore.domain.review.Review;
@@ -26,7 +27,7 @@ public class ReviewService {
     private final PlaceRepository placeRepository;
 
 
-    public Long saveReview(ReviewRequestDto dto) {
+    public ReviewDto saveReview(ReviewRequestDto dto) {
 
         /**
          * PlaceId를 현재 보고 있는 장소 Dto의 placeId로 주입이 가능할 경우
@@ -39,10 +40,10 @@ public class ReviewService {
         Review review = reviewRepository.save(dto.toEntity(user, place, dto.getTitle(), dto.getDescription(), dto.getReviewScore()));
         place.addScoreAndCount(dto.getReviewScore()); // 리뷰 점수 반영
 
-        return review.getId();
+        return ReviewDto.from(review);
     }
 
-    public Long updateReview(ReviewRequestDto dto) {
+    public ReviewDto updateReview(ReviewRequestDto dto) {
 
         Review review = reviewRepository.findById(dto.getId()).orElseThrow(ReviewNotFoundApiException::new);
         Place place = review.getPlace();
@@ -64,7 +65,7 @@ public class ReviewService {
             }
         }
 
-        return review.getId();
+        return ReviewDto.from(review);
     }
 
     public void deleteReview(Long id) {

--- a/module-api/src/main/java/dev/be/moduleapi/security/dto/AccessTokenDto.java
+++ b/module-api/src/main/java/dev/be/moduleapi/security/dto/AccessTokenDto.java
@@ -22,4 +22,10 @@ public class AccessTokenDto {
 
     @Schema(description = "액세스 토큰 만료일")
     private Long accessTokenExpireDate;
+
+    @Schema(description = "유저 ID")
+    private Long uid;
+
+    @Schema(description = "이메일")
+    private String email;
 }

--- a/module-api/src/main/java/dev/be/moduleapi/security/dto/TokenDto.java
+++ b/module-api/src/main/java/dev/be/moduleapi/security/dto/TokenDto.java
@@ -27,4 +27,10 @@ public class TokenDto {
     @Schema(description = "액세스 토큰 만료일")
     private Long accessTokenExpireDate;
 
+    @Schema(description = "유저 ID")
+    private Long uid;
+
+    @Schema(description = "이메일")
+    private String email;
+
 }

--- a/module-api/src/main/java/dev/be/moduleapi/security/jwt/JwtProvider.java
+++ b/module-api/src/main/java/dev/be/moduleapi/security/jwt/JwtProvider.java
@@ -56,7 +56,7 @@ public class JwtProvider {
     /**
      * JWT 생성
      */
-    public TokenDto createToken(String email, List<String> roles) {
+    public TokenDto createToken(String email, Long uid, List<String> roles) {
 
         // user 구분용, Claims에 email 추가
         Claims claims = Jwts.claims().setSubject(email);
@@ -82,6 +82,8 @@ public class JwtProvider {
                 .compact();
 
         return TokenDto.builder()
+                .email(email)
+                .uid(uid)
                 .grantType("bearer")
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
@@ -92,7 +94,7 @@ public class JwtProvider {
     /**
      * JWT 생성
      */
-    public AccessTokenDto refreshAccessToken(String email, List<String> roles) {
+    public AccessTokenDto refreshAccessToken(String email, Long uid, List<String> roles) {
 
         // user 구분용, Claims에 email 추가
         Claims claims = Jwts.claims().setSubject(email);
@@ -111,6 +113,8 @@ public class JwtProvider {
 
         return AccessTokenDto.builder()
                 .grantType("bearer")
+                .uid(uid)
+                .email(email)
                 .accessToken(accessToken)
                 .accessTokenExpireDate(ACCESS_TOKEN_VALID_MILLISECOND) // 발급 시간부터 1시간까지 유효
                 .build();

--- a/module-api/src/main/java/dev/be/moduleapi/support/controller/QnaApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/support/controller/QnaApiController.java
@@ -4,6 +4,7 @@ import dev.be.moduleapi.api.model.CommonResult;
 import dev.be.moduleapi.api.model.PageResult;
 import dev.be.moduleapi.api.model.SingleResult;
 import dev.be.moduleapi.api.service.ResponseService;
+import dev.be.moduleapi.support.dto.AnswerDto;
 import dev.be.moduleapi.support.dto.AnswerRequestDto;
 import dev.be.moduleapi.support.dto.QuestionDto;
 import dev.be.moduleapi.support.dto.QuestionRequestDto;
@@ -48,7 +49,7 @@ public class QnaApiController {
                     "문의 작성에 필요한 정보는 title, description, categoryId 입니다. <br>" +
                     "여기서 categoryId는 select option으로 받아야 합니다.")
     @PostMapping(value = "/api/v1/questions", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> saveQuestionV1(
+    public SingleResult<QuestionDto> saveQuestionV1(
             @Parameter(description = "요청한 유저의 인증 정보") Authentication authentication,
             @Parameter(description = "문의 작성 정보",
                     required = true,
@@ -71,7 +72,7 @@ public class QnaApiController {
                     "수정되는 정보는 title, description, categoryId 입니다. <br>" +
                     "또한 요청 시점에서 요청을 한 유저의 인증 정보를 확인하며, 해당 인증 정보를 토대로 문의를 수정하려는 유저를 체크합니다.")
     @PutMapping(value = "/api/v1/questions/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> updateQuestionV1(
+    public SingleResult<QuestionDto> updateQuestionV1(
             @Parameter(description = "사용자 정보", required = true) Authentication authentication,
             @Parameter(description = "문의 ID, 문의 리스트 내 문의의 id를 사용합니다", required = true) @PathVariable("id") Long id,
             @Parameter(description = "문의 수정 정보, 수정 버튼 클릭 시 [GET] /api/v1/questions/{id}로 수정 전 정보를 가져와야 합니다.",
@@ -138,7 +139,7 @@ public class QnaApiController {
                     "리뷰 작성에 필요한 정보는 문의 ID(qid), description 입니다. <br>" +
                     "여기서 문의 ID는 프론트엔드에서 요청 시 해당 답변이 작성될 문의 ID(qid)를 넣어줘야 합니다. (문의 화면 내에서 답변 작성)")
     @PostMapping(value = "/api/v1/answers", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public SingleResult<Long> saveAnswerV1(
+    public SingleResult<AnswerDto> saveAnswerV1(
             @Parameter(description = "요청한 유저의 인증 정보") Authentication authentication,
             @Parameter(description = "답변 작성 정보",
                     required = true,

--- a/module-api/src/main/java/dev/be/moduleapi/support/service/QnaService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/support/service/QnaService.java
@@ -1,7 +1,9 @@
 package dev.be.moduleapi.support.service;
 
 import dev.be.moduleapi.advice.exception.UserNotFoundApiException;
+import dev.be.moduleapi.support.dto.AnswerDto;
 import dev.be.moduleapi.support.dto.AnswerRequestDto;
+import dev.be.moduleapi.support.dto.QuestionDto;
 import dev.be.moduleapi.support.dto.QuestionRequestDto;
 import dev.be.modulecore.domain.support.Answer;
 import dev.be.modulecore.domain.support.Question;
@@ -31,17 +33,17 @@ public class QnaService {
     private final UserRepository userRepository;
 
 
-    public Long saveQuestion(QuestionRequestDto dto) {
+    public QuestionDto saveQuestion(QuestionRequestDto dto) {
 
         User user = userRepository.findByNickname(dto.getNickname()).orElseThrow(UserNotFoundApiException::new);
         QuestionCategory questionCategory = questionCategoryRepository.findById(dto.getCategoryId()).orElseThrow(EntityNotFoundException::new);
         Question question = questionRepository.save(dto.toEntity(dto.getTitle(), dto.getDescription(), user, questionCategory));
 
-        return question.getId();
+        return QuestionDto.from(question);
 
     }
 
-    public Long updateQuestion(QuestionRequestDto dto) {
+    public QuestionDto updateQuestion(QuestionRequestDto dto) {
 
         Question question = questionRepository.findById(dto.getId()).orElseThrow(EntityNotFoundException::new);
 
@@ -51,7 +53,7 @@ public class QnaService {
             question.changeCategory(questionCategoryRepository.findById(dto.getCategoryId()).orElseThrow(EntityNotFoundException::new));
         }
 
-        return question.getId();
+        return QuestionDto.from(question);
 
     }
 
@@ -61,14 +63,14 @@ public class QnaService {
 
     }
 
-    public Long saveAnswer(AnswerRequestDto dto) {
+    public AnswerDto saveAnswer(AnswerRequestDto dto) {
 
         User user = userRepository.findByNickname(dto.getNickname()).orElseThrow(UserNotFoundApiException::new);
         Question question = questionRepository.findById(dto.getQid()).orElseThrow(EntityNotFoundException::new);
 
         Answer answer = answerRepository.save(dto.toEntity(user, question, dto.getDescription()));
 
-        return answer.getId();
+        return AnswerDto.from(answer);
 
     }
 

--- a/module-api/src/main/java/dev/be/moduleapi/user/service/UserJoinService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/user/service/UserJoinService.java
@@ -68,7 +68,7 @@ public class UserJoinService {
 
         // 액세스 토큰, 리프레시 토큰 발급
         log.info("create token start");
-        TokenDto tokenDto = jwtProvider.createToken(user.getEmail(), user.getRoleSet());
+        TokenDto tokenDto = jwtProvider.createToken(user.getEmail(), user.getUid(), user.getRoleSet());
         log.info("create token complete");
 
         // 리프레시 토큰 저장
@@ -136,7 +136,7 @@ public class UserJoinService {
 
         User user = userRepository.findByEmailAndProvider(profile.getEmail(), provider).orElseThrow(UserNotFoundApiException::new);
 
-        TokenDto tokenDto = jwtProvider.createToken(user.getEmail(), user.getRoleSet());
+        TokenDto tokenDto = jwtProvider.createToken(user.getEmail(), user.getUid(), user.getRoleSet());
 
         // 리프레시 토큰 저장
         log.info("refresh token persist start");
@@ -173,7 +173,7 @@ public class UserJoinService {
             throw new CustomRefreshTokenException();
 
         // 액세스 토큰 재발급
-        return jwtProvider.refreshAccessToken(user.getEmail(), user.getRoleSet());
+        return jwtProvider.refreshAccessToken(user.getEmail(), user.getUid(), user.getRoleSet());
 
     }
 


### PR DESCRIPTION
기존에는 생성 / 수정 시 생성, 수정된 데이터의 id값만 리턴하였으나 프론트엔드에서 화면 처리 로직과 맞지 않아 id값이 아닌 DTO로 반환하여 전달하게끔 변경. 또한, 인증 관련해서 추가 수정

* [x] 액세스 토큰 전달 시 uid, email 전달
* [x] 생성 / 수정 응답 스펙 변경

This closes #127 