### PR TITLE
[BE] 장소 추천 API 기능 수정

### DIFF
--- a/module-api/src/main/java/dev/be/moduleapi/config/SecurityConfig.java
+++ b/module-api/src/main/java/dev/be/moduleapi/config/SecurityConfig.java
@@ -113,6 +113,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(Arrays.asList("*"));
         configuration.addAllowedOrigin("http://localhost:5173");
+        configuration.addAllowedOrigin("https://mrcocoball.github.io");
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);

--- a/module-api/src/main/java/dev/be/moduleapi/place/controller/PlaceRecommendationApiController.java
+++ b/module-api/src/main/java/dev/be/moduleapi/place/controller/PlaceRecommendationApiController.java
@@ -39,10 +39,9 @@ public class PlaceRecommendationApiController {
     @GetMapping("/api/v1/recommendation")
     public PageResult<PlaceRecommendationDto> getRecommendationV1(@Parameter(description = "시/도") @RequestParam(required = false) String region1,
                                                                   @Parameter(description = "군/구") @RequestParam(required = false) String region2,
-                                                                  @Parameter(description = "동/읍/면") @RequestParam(required = false) String region3,
                                                                   @ParameterObject @PageableDefault(size = 10, sort = "avgReviewScore", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        return responseService.getPageResult(placeRecommendationService.getPlaceRecommendation(region1, region2, region3, pageable));
+        return responseService.getPageResult(placeRecommendationService.getPlaceRecommendation(region1, region2, pageable));
     }
 
 }

--- a/module-api/src/main/java/dev/be/moduleapi/place/repository/PlaceRecommendationRepository.java
+++ b/module-api/src/main/java/dev/be/moduleapi/place/repository/PlaceRecommendationRepository.java
@@ -29,8 +29,7 @@ public class PlaceRecommendationRepository {
     // TODO : 현재 리뷰 데이터가 많지 않아서 단순 평점만으로 정렬하기에는 다소 엉성한 감이 있다.
     //  데이터가 많이 쌓일 경우 리뷰 횟수에도 조건을 두어 평점의 신뢰도를 조금이라도 높이는 것이 좋을 듯 하다.
     public List<PlaceRecommendationDto> placeRecommendation(@Param("region1") String region1,
-                                                            @Param("region2") String region2,
-                                                            @Param("region3") String region3) {
+                                                            @Param("region2") String region2) {
 
         NumberExpression<Long> avgReviewScorePath = place.reviewScore.divide(place.reviewCount);
 
@@ -49,7 +48,7 @@ public class PlaceRecommendationRepository {
                 .from(place)
                 .leftJoin(place.category, category)
                 .where(
-                        recommendationCondition(region1, region2, region3)
+                        recommendationCondition(region1, region2)
                 )
                 .orderBy(avgReviewScorePath.desc())
                 .limit(50)
@@ -63,17 +62,13 @@ public class PlaceRecommendationRepository {
     private BooleanExpression region2Eq(String region2) {
         return hasText(region2) ? place.region2DepthName.eq(region2) : null;
     }
-
-    private BooleanExpression region3Cont(String region3) {
-        return hasText(region3) ? place.region3DepthName.startsWith(region3) : null;
-    }
     
     private BooleanExpression categoryEq(String category) {
         return hasText(category) ? QCategory.category.id.eq(category) : null;
     }
 
-    private BooleanExpression recommendationCondition(String region1, String region2, String region3) {
-        return region1Eq(region1).and(region2Eq(region2)).and(region3Cont(region3));
+    private BooleanExpression recommendationCondition(String region1, String region2) {
+        return region1Eq(region1).and(region2Eq(region2));
     }
 
 }

--- a/module-api/src/main/java/dev/be/moduleapi/place/service/PlaceRecommendationService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/place/service/PlaceRecommendationService.java
@@ -26,9 +26,9 @@ public class PlaceRecommendationService {
     private final PaginationService paginationService;
 
 
-    public Page<PlaceRecommendationDto> getPlaceRecommendation(String region1, String region2, String region3, Pageable pageable) {
+    public Page<PlaceRecommendationDto> getPlaceRecommendation(String region1, String region2, Pageable pageable) {
 
-        List<PlaceRecommendationDto> result = placeRecommendationRepository.placeRecommendation(region1, region2, region3);
+        List<PlaceRecommendationDto> result = placeRecommendationRepository.placeRecommendation(region1, region2);
 
         if (Objects.isNull(result) || result.isEmpty()) {
             log.error("[PlaceRecommendationService getPlaceRecommendation] recommendation result is null");

--- a/module-api/src/main/java/dev/be/moduleapi/review/dto/ReviewDto.java
+++ b/module-api/src/main/java/dev/be/moduleapi/review/dto/ReviewDto.java
@@ -20,6 +20,9 @@ public class ReviewDto {
     @Schema(description = "리뷰 ID")
     private Long id;
 
+    @Schema(description = "리뷰 작성자 ID(PK)")
+    private Long uid;
+
     @Schema(description = "리뷰 작성자 닉네임")
     private String nickname;
 
@@ -66,6 +69,7 @@ public class ReviewDto {
 
         return ReviewDto.builder()
                 .id(entity.getId())
+                .uid(entity.getUser().getUid())
                 .nickname(entity.getUser().getNickname())
                 .pid(entity.getPlace().getId())
                 .placeId(entity.getPlace().getPlaceId())

--- a/module-api/src/main/java/dev/be/moduleapi/review/service/ReviewService.java
+++ b/module-api/src/main/java/dev/be/moduleapi/review/service/ReviewService.java
@@ -29,11 +29,6 @@ public class ReviewService {
 
     public ReviewDto saveReview(ReviewRequestDto dto) {
 
-        /**
-         * PlaceId를 현재 보고 있는 장소 Dto의 placeId로 주입이 가능할 경우
-         * 이렇게 처리하고, 그게 아니라면 수정이 필요할 것으로 보임
-         */
-
         User user = userRepository.findByNickname(dto.getNickname()).orElseThrow(UserNotFoundApiException::new);
         Place place = placeRepository.findByPlaceId(dto.getPlaceId()).orElseThrow(PlaceNotFoundApiException::new);
 

--- a/module-api/src/test/java/dev/be/moduleapi/place/service/PlaceRecommendationServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/place/service/PlaceRecommendationServiceTest.java
@@ -36,16 +36,15 @@ class PlaceRecommendationServiceTest {
         // Given
         String address1 = "서울";
         String address2 = "관악구";
-        String address3 = "봉천동";
 
         Pageable pageable = Pageable.ofSize(10);
-        given(placeRecommendationRepository.placeRecommendation(address1, address2, address3)).willReturn(Collections.emptyList());
+        given(placeRecommendationRepository.placeRecommendation(address1, address2)).willReturn(Collections.emptyList());
 
         // When & Then
         assertThrows(SearchResultNotFoundException.class, () -> {
-            sut.getPlaceRecommendation(address1, address2, address3, pageable);
+            sut.getPlaceRecommendation(address1, address2, pageable);
         });
-        then(placeRecommendationRepository).should().placeRecommendation(address1, address2, address3);
+        then(placeRecommendationRepository).should().placeRecommendation(address1, address2);
 
     }
 


### PR DESCRIPTION
API 기능 구현 당시 시,도 / 군,구 / 읍,면,동 으로 주소를 선택할 수 있게 하였으나 읍,면,동까지 선택 범위를 확대하기에 프론트엔드 쪽 로직이 복잡해질 우려가 있고 대부분 시,도 / 군,구까지만 선택 범위를 두는 경우가 많아 읍,면,동은 선택 범위에서 제외하도록 수정한다

* [x] 요청 사항에 읍,면,동 삭제
* [x] 테스트 수정

This closes #136 