### PR TITLE
[BE] 어드민 서버, 테스트 코드 수정

### DIFF
--- a/module-admin/src/main/java/dev/be/moduleadmin/place/dto/PlaceRequestDto.java
+++ b/module-admin/src/main/java/dev/be/moduleadmin/place/dto/PlaceRequestDto.java
@@ -45,6 +45,7 @@ public class PlaceRequestDto {
                           double longitude, double latitude, String imageUrl, String description) {
         return Place.of(
                 Category.of(categoryGroupId),
+                categoryGroupId,
                 placeName,
                 placeId,
                 placeUrl,

--- a/module-admin/src/test/java/dev/be/fixture/Fixture.java
+++ b/module-admin/src/test/java/dev/be/fixture/Fixture.java
@@ -39,6 +39,7 @@ public class Fixture {
     public static Place place() {
         return Place.of(
                 category(),
+                category().getId(),
                 "testplace",
                 "1",
                 "testurl",

--- a/module-api/src/test/java/dev/be/fixture/Fixture.java
+++ b/module-api/src/test/java/dev/be/fixture/Fixture.java
@@ -41,6 +41,7 @@ public class Fixture {
     public static Place place() {
         return Place.of(
                 category(),
+                category().getId(),
                 "testplace",
                 "1",
                 "testurl",
@@ -59,6 +60,7 @@ public class Fixture {
     public static Place newPlace() {
         return Place.of(
                 category(),
+                category().getId(),
                 "testplace2",
                 "2",
                 "testurl2",

--- a/module-api/src/test/java/dev/be/moduleapi/ModuleApiApplicationTests.java
+++ b/module-api/src/test/java/dev/be/moduleapi/ModuleApiApplicationTests.java
@@ -2,8 +2,9 @@ package dev.be.moduleapi;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active:local")
 class ModuleApiApplicationTests {
 
     @Test

--- a/module-api/src/test/java/dev/be/moduleapi/kakao/service/KakaoAddressSearchServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/kakao/service/KakaoAddressSearchServiceTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("[통합] 카카오 API - 카카오 주소 - 위치 변환 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active:local")
 class KakaoAddressSearchServiceTest {
 
     @Autowired

--- a/module-api/src/test/java/dev/be/moduleapi/kakao/service/KakaoCategorySearchServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/kakao/service/KakaoCategorySearchServiceTest.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("[통합] 카카오 API - 카카오 카테고리 장소 검색 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active:local")
 class KakaoCategorySearchServiceTest {
 
     @Autowired

--- a/module-api/src/test/java/dev/be/moduleapi/place/service/PlaceApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/place/service/PlaceApiServiceTest.java
@@ -31,7 +31,7 @@ import static org.mockito.BDDMockito.then;
 
 @DisplayName("[통합] 장소 화면 처리 서비스 - 장소 조회 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active:local")
 class PlaceApiServiceTest {
 
     @Autowired

--- a/module-api/src/test/java/dev/be/moduleapi/place/service/PlaceRecommendationServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/place/service/PlaceRecommendationServiceTest.java
@@ -19,7 +19,7 @@ import static org.mockito.BDDMockito.then;
 
 @DisplayName("[통합] 장소 추천 서비스 - 장소 추천 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active:local")
 class PlaceRecommendationServiceTest {
 
     @Autowired

--- a/module-api/src/test/java/dev/be/moduleapi/support/service/AnnouncementApiServiceTest.java
+++ b/module-api/src/test/java/dev/be/moduleapi/support/service/AnnouncementApiServiceTest.java
@@ -26,7 +26,7 @@ import static org.mockito.BDDMockito.then;
 
 @DisplayName("[통합] 공지사항 화면 처리 서비스 - 공지사항 조회 테스트")
 @ExtendWith(MockitoExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "spring.profiles.active:local")
 class AnnouncementApiServiceTest {
 
     @Autowired


### PR DESCRIPTION
다음과 같은 내용에 대해 코드를 수정

* [x] 어드민 서버 장소 요청 DTO -> 엔티티 전환 시 카테고리 코드 누락된 점 수정
* [x] 장소 Fixture 생성 시 카테고리 코드 미기입되어 있던 점 수정
* [x] API 서버 통합 테스트 시 spring.active.profile 설정 부여하도록 수정

This closes #147 